### PR TITLE
Fix `preload` issue...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ browser/mini-rt.tar: tools/preload
 tools/preload:
 	make opt
 	@echo "Generating list of files to preload in browser... (will take a few seconds)"
-	@node build/opt/console/runner.js classes/util/Javac --java=./classes/test/FileOps.java --list-class-cache > tools/preload
+	@node build/opt/console/runner.js --classpath build/opt classes/util/Javac --java=./classes/test/FileOps.java --list-class-cache > tools/preload
 
 ################################################################################
 # BUILD DIRECTORY TARGETS

--- a/console/runner.coffee
+++ b/console/runner.coffee
@@ -155,6 +155,7 @@ if require.main == module
     run()
 
   if argv['list-class-cache']
+    scriptdir = path.resolve(__dirname + "/..")
     for k in Object.keys rs.loaded_classes
       # Find where it was loaded from.
       file = k + ".class"
@@ -162,7 +163,8 @@ if require.main == module
         fpath = cpath + '/' + file
         try
           if fs.statSync(fpath).isFile()
-            console.log(path.resolve(fpath))
+            fpath = path.resolve(fpath).substr(scriptdir.length+1)
+            console.log(fpath)
             break
         catch e
           # Do nothing; iterate.


### PR DESCRIPTION
With my previous changes, `preload` was generated with absolute paths, which were mimicked in `mini-rt.tar` (e.g. `/Users/jvilk/Code/doppio....` directories were in the file).

This changes the output to be relative directories like before, which works fine.
