### PR TITLE
Fix --profile

### DIFF
--- a/console/runner.coffee
+++ b/console/runner.coffee
@@ -51,7 +51,7 @@ run_profiled = (runner, rs, cname, hot=false) ->
 
     arr = (name: k, total: total_timings[k], self: v, counts:call_counts[k] for k, v of self_timings)
     arr.sort (a, b) -> b.self - a.self
-    total_time = total_timings["#{cname}::main([Ljava/lang/String;)"]
+    total_time = total_timings["L#{cname};::main([Ljava/lang/String;)V"]
 
     console.log "\nProfiler results: #{total_time} ms total"
     console.log ['total','self','calls','self ms/call','name'].join '\t'


### PR DESCRIPTION
The profiling output for console/runner is broken. The current output for classes/demo/Fib looks like this:

```
Profiler results: undefined ms total
total   self    calls   self ms/call    name
```

There seem to be a couple problems with run_profiled:
1. The hash of the caller and method signatures used javascript code instead of the actual signatures: https://github.com/brucespang/doppio/commit/70c08ad4969df680a21f2020949b6e0228ede2c2#L0L22
2. Calling runner() seems to asynchronously initialize the main thread, and then immediately return. Since it returns before the main thread is actually executed, no profiling data is actually collected: https://github.com/brucespang/doppio/commit/70c08ad4969df680a21f2020949b6e0228ede2c2#L0L36

These are fixed in this commit:
1. Instead of using the contents of functions that get the signatures, call the functions to get the actual signatures: https://github.com/brucespang/doppio/commit/70c08ad4969df680a21f2020949b6e0228ede2c2#L0R24
2. Add a callback to runner to be executed when the program finishes. Print out the profiling results from this callback, to ensure that the program is run to completion before results are printed: https://github.com/brucespang/doppio/commit/70c08ad4969df680a21f2020949b6e0228ede2c2#L0R39

This makes the profiling output look like a better formatted version of this, which seems much more useful:

```
Profiler results: 6 ms total
total   self    calls   self ms/call    name
100 100 6   16.7    Lsun/security/action/GetPropertyAction;::<init>(Ljava/lang/String;)V
41  41  1   41.0    Lsun/nio/cs/StandardCharsets$Aliases;::init([Ljava/lang/Object;)V
36  36  6   6.0 Lsun/security/action/GetPropertyAction;::run()Ljava/lang/String;
35  35  17  2.1 Ljava/lang/String;::hashCode()I
...
```
