### PR TITLE
Fixed disassembler.coffee output conformance with certain modifiers on inner classes

### DIFF
--- a/classes/test/InnerClass.java
+++ b/classes/test/InnerClass.java
@@ -1,6 +1,13 @@
 // test inner classes
 package classes.test;
 public abstract class InnerClass {
+  // These first few classes are used to check disassembler
+  // conformance
+  private static class PrivateInner {}
+  private abstract class PrivateInnerAbstract {}
+  protected class ProtectedInner {}
+  protected abstract class ProtectedInnerAbstract {}
+  
   public abstract void run();
   public static void runFunctor(InnerClass a){
     a.run();

--- a/src/disassembler.coffee
+++ b/src/disassembler.coffee
@@ -96,7 +96,7 @@ make_dis = (class_file) ->
     for cls in icls.classes
       flags = util.parse_flags cls.inner_access_flags
       icls_group.push
-        access_string: (f+' ' for f in ['public', 'protected', 'private', 'abstract'] when flags[f]).join ''
+        access_string: (f+' ' for f in ['public', 'abstract'] when flags[f]).join ''
         type: util.descriptor2typestr pool.get(cls.inner_info_index).deref()
         raw: cls  # useful for inner/outer indices
         name: if cls.inner_name_index > 0 then pool.get(cls.inner_name_index).value else null


### PR DESCRIPTION
I discovered this issue when I was working on support for park/unpark using inner classes. It appears that javap doesn't include the "private" or "protected" keywords on inner classes, but does include "public" and "abstract". This pull request addresses this issue and adds several empty inner classes with modifiers to the InnerClass.java test.
