### PR TITLE
avoid self-referential symlinks (fixes int3/doppio#257)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ doppio doppio-dev:
 BUILD_FOLDERS = build/% build/%/browser build/%/console build/%/src
 $(foreach TARGET,$(BUILD_TARGETS),$(subst %,$(TARGET),$(BUILD_FOLDERS))):
 	mkdir -p $@
-	ln -s vendor $@/vendor
+	ln -s $(DOPPIO_DIR)/vendor $@/vendor
 
 # Prevent this from being treated as pattern rule (because it has multiple targets)
 $(foreach TARGET,$(BUILD_TARGETS),$(subst %,$(TARGET),build/%/classes build/%/vendor)): $(foreach TARGET,$(BUILD_TARGETS),$(subst %,$(TARGET),build/%))


### PR DESCRIPTION
I'm not sure if this really captures the original intent, but it seems to alleviate the warning message and basic usage in the browser-based console still works okay for me.
