### PR TITLE
ensure tar only includes one copy of each preload file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ tools/preload: release-cli
 	fi
 
 build/%/browser/mini-rt.tar: build/%/browser tools/preload
-	COPYFILE_DISABLE=true && tar -c -T <(sort -u tools/preload) -f $@
+	COPYFILE_DISABLE=true && tar -c -h -T <(sort -u tools/preload) -f $@
 
 # The | prevents the prerequisite from being included in $^, and avoids
 # re-executing the rule when the folder is 'updated' with `mkdir -p`.


### PR DESCRIPTION
I got an error down in the guts of BrowserFS because there was a second copy of `java/lang/Runtime.class` in `mini-rt.tar` that was a symlink.  Since it was zero bytes long, the attempt to check for `0xCAFEBABE` at the beginning of it failed with a RangeError (in FF).  There may be some issue further up the chain that caused `Runtime.class` to get listed twice in `tools/preload`, but this works around it nicely.
