### PR TITLE
Use /usr/libexec/java_home to locate Java 1.6 on OS X

### DIFF
--- a/tasks/find_native_java.ts
+++ b/tasks/find_native_java.ts
@@ -57,8 +57,24 @@ function find_native_java(grunt: IGrunt) {
         };
       get_registry_key('HKLM\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.6', valueCb);
       get_registry_key('HKLM\\SOFTWARE\\Wow6432Node\\JavaSoft\\Java Development Kit\\1.6', valueCb);
+    } else if (process.platform.match(/darwin/i)) {
+      // OS X: locate Java 6 with java_home
+      exec('/usr/libexec/java_home -version 1.6', function (err, stdout, stderr) {
+        if (err) {
+          cb(new Error("Cannot run /usr/libexec/java_home"));
+        } else {
+          var javaHome = stdout.toString().replace('\n', '');
+          var java_bin = path.resolve(javaHome, 'bin');
+
+          grunt.config.set('build.java', path.resolve(java_bin, 'java'));
+          grunt.config.set('build.javac', path.resolve(java_bin, 'javac'));
+          grunt.config.set('build.javap', path.resolve(java_bin, 'javap'));
+
+          cb();
+        }
+      });
     } else {
-      // *nix / Mac
+      // *nix
       // Option 1: Can we invoke 'java' directly?
       exec(grunt.config('build.java') + ' -version', function(err, stdout, stderr) {
         if (err) {


### PR DESCRIPTION
On OS X Mavericks with Java 7, `grunt release` fails with:

```
Running "find_native_java" task
Locating your Java 6 installation...
>> Java: java
>> Javap: javap
>> Javac: javac
Fatal error: Detected Java 1.7.0 (via javac). Please use Java <= 1.6
```

since its trying to use the "default" Java installation, even though Java 6 is also installed. To find it, changed the `find_native_java.ts` task to use `/usr/libexec/java_home` to specifically ask for this version, now setup succeeds:

```
Running "find_native_java" task
Locating your Java 6 installation...
>> Java: /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin/java
>> Javap: /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin/javap
>> Javac: /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin/javac
```
