### PR TITLE
Thread being deleted incorrectly by splice method

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -616,7 +616,9 @@ export class RuntimeState {
         // remove the current (finished) thread
         debug("TE(toplevel): finished thread " + _this.curr_thread.name(_this));
         _this.curr_thread.$isAlive = false;
-        _this.thread_pool.splice(_this.thread_pool.indexOf(_this.curr_thread), 1);
+        if(_this.thread_pool.indexOf(_this.curr_thread) > 0){
+            _this.thread_pool.splice(_this.thread_pool.indexOf(_this.curr_thread), 1);
+        }
         return _this.choose_next_thread(null, function (next_thread) {
           _this.curr_thread = next_thread;
           _this.run_until_finished(nop, no_threads, done_cb);


### PR DESCRIPTION
I'm doing something with doppio.I found sometimes my program exited accidentally.The console show me logs like this(filter the thread message):

TE(start0): starting Thread-4 from Thread-2
TE(start0): starting Thread-5 from Thread-2
TE(start0): thread died: Thread-5
TE(toplevel): finished thread Thread-5
TE(start0): starting Thread-6 from Thread-2
TE(start0): thread died: Thread-6
TE(toplevel): finished thread Thread-6
TE(start0): thread died: Thread-4
TE(toplevel): finished thread Thread-4
TE(toplevel): finished thread Thread-4

I do not know why thread Thread-4 was finished twice.But then my program exited.

I found in method run_until_finished,thread was removed by splice method:

_this.thread_pool.splice(_this.thread_pool.indexOf(_this.curr_thread), 1);

For the second time it tried to finish thread Thread-4,the Thread-4 was not in the pool so the _this.thread_pool.indexOf(_this.curr_thread) is -1,but with splice method,the last element(acturally it is my thread Thread-2) in the pool will be deleted by statement _this.thread_pool.splice(-1,1).

Changed the code to:
if(_this.thread_pool.indexOf(_this.curr_thread) > 0){
_this.thread_pool.splice(_this.thread_pool.indexOf(_this.curr_thread), 1);
}
and my problem was resolved.

So maybe we need to check if the thread is really in the thread_pool and then continue to delete it ?
