### PR TITLE
Change os.tmpDir() to os.tmpdir() in Grunttasks.ts

### DIFF
--- a/Grunttasks.ts
+++ b/Grunttasks.ts
@@ -41,7 +41,7 @@ export function setup(grunt: IGrunt) {
       jcl_dir: '<%= resolve(build.java_home_dir, "classes") %>',
       build_dir: '<%= resolve(build.doppio_dir, "build", build.build_type) %>',
       // TODO: Maybe fix this to prevent us from using too much scratch space?
-      scratch_dir: path.resolve(os.tmpDir(), "jdk-download" + Math.floor(Math.random() * 100000))
+      scratch_dir: path.resolve(os.tmpdir(), "jdk-download" + Math.floor(Math.random() * 100000))
     },
     make_build_dir: {
       options: { build_dir: "<%= build.build_dir %>" },


### PR DESCRIPTION
The 'grunt release' command in the installation instructions fails on OS X with the following error:

```
error TS2339: Property 'tmpDir' does not exist on type 'typeof "os"'.
```

This is fixed by changing the case of os.tmpDir() to os.tmpdir(), which is the correct name of the function: http://nodejs.org/api/os.html#os_os_tmpdir
