### PR TITLE
Implement byte Write method in RandomAccessFile class

### DIFF
--- a/classes/test/FileWrite.java
+++ b/classes/test/FileWrite.java
@@ -1,0 +1,27 @@
+// read a local file
+package classes.test;
+import java.io.*;
+public class FileWrite {
+  public static void main(String[] args) {
+    try {
+      StringWriter stringWriter = new StringWriter();
+
+      // replace by createTempFile when we get around to supporting it
+      RandomAccessFile file = new RandomAccessFile("/tmp/Doppio-FileWriteTest", "rw");
+      int[] arr = {89, 69, 83};
+      for(int byteValue : arr) {
+          file.write(byteValue);
+      }
+
+      file.seek(0);
+
+      for(int byteValue : arr) {
+        if (file.read() != byteValue) {
+          throw new RuntimeException("RandomAccessFile byte write method failed.");
+        }
+      }
+    } catch (IOException e) {
+      System.err.println(e.getMessage());
+    }
+  }
+}

--- a/src/natives/java_io.ts
+++ b/src/natives/java_io.ts
@@ -439,8 +439,20 @@ class java_io_RandomAccessFile {
     });
   }
 
-  public static 'write0(I)V'(thread: threading.JVMThread, javaThis: JVMTypes.java_io_RandomAccessFile, arg0: number): void {
-    thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented.');
+  public static 'write0(I)V'(thread: threading.JVMThread, javaThis: JVMTypes.java_io_RandomAccessFile, value: number): void {
+    var fdObj = javaThis["java/io/RandomAccessFile/fd"];
+    var fd = fdObj["java/io/FileDescriptor/fd"];
+
+    thread.setStatus(enums.ThreadStatus.ASYNC_WAITING);
+    fs.write(fd, String.fromCharCode(value), fdObj.$pos, (err, numBytes) => {
+      if (err != null) {
+        thread.throwNewException('Ljava/io/IOException;', 'Erorr reading file: ' + err);
+      }
+
+      fdObj.$pos += numBytes;
+      thread.asyncReturn();
+    });
+
   }
 
   public static 'writeBytes([BII)V'(thread: threading.JVMThread, javaThis: JVMTypes.java_io_RandomAccessFile, byteArr: JVMTypes.JVMArray<number>, offset: number, len: number): void {


### PR DESCRIPTION
After createTempFile will be supported test should be updated because we need to use proper temporary file logic for tests.

I've also noticed interested way of writing tests in this project. What's the point of displaying exception in runout file while running `grunt test` returns `Done, without errors.`?

Fully tested, works as expected.