### PR TITLE
configurable responsiveness

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -36,6 +36,8 @@ export interface JVMOptions {
   properties?: {[name: string]: string};
   // Path where DoppioJVM can store temporary files. Defaults to /tmp.
   tmpDir?: string;
+  // Responsiveness of JVM (expressed in milliseconds before a thread yields co-operatively)
+  responsiveness?: number | (() => number);
 }
 
 /**

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -78,6 +78,7 @@ class JVM {
   private terminationCb: (code: number) => void = null;
   // The initial JVM thread used to kick off execution.
   private firstThread: JVMThread = null;
+  private responsiveness: number | (() => number) = null;
   private enableSystemAssertions: boolean = false;
   private enabledAssertions: boolean | string[] = false;
   private disabledAssertions: string[] = [];
@@ -134,6 +135,9 @@ class JVM {
     if (opts.disableAssertions) {
       this.disabledAssertions = opts.disableAssertions;
     }
+
+    this.responsiveness = opts.responsiveness;
+
     this._initSystemProperties(bootstrapClasspath,
       opts.classpath.map((p: string): string => path.resolve(p)),
       path.resolve(opts.javaHomePath),
@@ -256,6 +260,15 @@ class JVM {
     });
   }
 
+  public getResponsiveness():number {
+    const resp = this.responsiveness;
+    if (typeof resp === 'number') {
+      return resp;
+    } else if (typeof resp === 'function') {
+      return resp();
+    }
+  }
+
   public static getDefaultOptions(doppioHome: string): interfaces.JVMOptions {
     let javaHome = path.join(doppioHome, 'vendor', 'java_home');
     return {
@@ -268,7 +281,8 @@ class JVM {
       enableAssertions: false,
       disableAssertions: null,
       properties: {},
-      tmpDir: '/tmp'
+      tmpDir: '/tmp',
+      responsiveness: 1000
     };
   }
 

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -26,8 +26,6 @@ var debug = logging.debug, vtrace = logging.vtrace, trace = logging.trace,
   maxMethodResumes: number = 10000,
   // The number of method resumes until Doppio should yield again.
   methodResumesLeft: number = maxMethodResumes,
-  // How responsive Doppio should aim to be, in milliseconds.
-  responsiveness: number = 1000,
   // Used for the CMA.
   numSamples: number = 1;
 
@@ -679,7 +677,7 @@ export class JVMThread implements Thread {
         const endTime = (new Date()).getTime();
         const duration = endTime - startTime;
         // Estimated number of methods we can resume before needing to yield.
-        const estMaxMethodResumes = ((maxMethodResumes / duration) * responsiveness) | 0;
+        const estMaxMethodResumes = ((maxMethodResumes / duration) * this.jvm.getResponsiveness()) | 0;
         // Update CMA.
         maxMethodResumes = ((estMaxMethodResumes + numSamples * maxMethodResumes) / (numSamples + 1)) | 0;
         if (maxMethodResumes <= 0) {


### PR DESCRIPTION
responsiveness can now be specified in doppio options, either as:
* a number
* a function that returns a number

The number is interpreted as a duration in milliseconds after which the thread should yield.

Closes #404