### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: required
+dist: trusty
+jdk: oraclejdk8
+
 language: node_js
 
 matrix:
@@ -6,8 +10,6 @@ matrix:
       env: TEST_BROWSER=0
     - node_js: "stable"
       env: TEST_BROWSER=1
-
-sudo: false
 
 cache:
   directories:
@@ -22,9 +24,6 @@ install:
 
 addons:
   firefox: "latest"
-  apt:
-    packages:
-      - oracle-java8-installer
 
 before_script:
   - export DISPLAY=:99.0

--- a/tasks/test/harness_webworker.ts
+++ b/tasks/test/harness_webworker.ts
@@ -20,7 +20,7 @@ let state = State.INITIAL,
  * Test harness portion that runs in a WebWorker.
  */
 onmessage = function(e) {
-  let data: Message = e.data;
+  const data: Message = e.data;
   switch (data.type) {
     case MessageType.RUN_TEST: {
       if (state !== State.WAITING_FOR_TEST) {
@@ -32,6 +32,7 @@ onmessage = function(e) {
         state = State.WAITING_FOR_TEST;
         let results: TestResultMessage = {
           type: MessageType.TEST_RESULT,
+          id: data.id,
           err: err ? "" + err : null,
           stack: err ? err.stack : null,
           actual: actual,
@@ -53,6 +54,7 @@ onmessage = function(e) {
 
         let listing: TestListingMessage = {
           type: MessageType.TEST_LISTING,
+          id: data.id,
           listing: tests.map((test) => test.cls)
         };
         (<any> postMessage)(listing);

--- a/tasks/test/messages.ts
+++ b/tasks/test/messages.ts
@@ -9,6 +9,7 @@ export enum MessageType {
 
 export interface Message {
   type: MessageType;
+  id: number;
 }
 
 export interface SetupMessage extends Message {


### PR DESCRIPTION
For #406 

The test harness was registering and unregistering listeners after every message, which was probably what was crashing Firefox. I have created a single listener and it seems to be stable for the last 4-5 builds.

Also upgraded to the new travis infrastucture (sudo: required), which is based on ubuntu trusty and has direct support for installing java 8. This seems to have fixed the javac failures.