### PR TITLE
Fix and implement some nio.file functions

### DIFF
--- a/Grunttasks.ts
+++ b/Grunttasks.ts
@@ -145,7 +145,7 @@ export function setup(grunt: IGrunt) {
         dest: "includes",
         // The following classes are referenced by DoppioJVM code, but aren't
         // referenced by any JVM classes directly for some reason.
-        force: ['sun.nio.fs.UnixConstants', 'sun.nio.fs.DefaultFileSystemProvider', 'sun.nio.fs.UnixException', 'java.lang.ExceptionInInitializerError', 'java.nio.charset.Charset$3', 'java.lang.invoke.MethodHandleNatives$Constants', 'java.lang.reflect.InvocationTargetException', 'java.nio.DirectByteBuffer', 'java.security.PrivilegedActionException'],
+        force: ['java.nio.file.NoSuchFileException', 'java.nio.file.FileAlreadyExistsException', 'sun.nio.fs.UnixConstants', 'sun.nio.fs.DefaultFileSystemProvider', 'sun.nio.fs.UnixException', 'java.lang.ExceptionInInitializerError', 'java.nio.charset.Charset$3', 'java.lang.invoke.MethodHandleNatives$Constants', 'java.lang.reflect.InvocationTargetException', 'java.nio.DirectByteBuffer', 'java.security.PrivilegedActionException'],
         headersOnly: true
       },
       default: {}

--- a/classes/test/NioFilesPaths.java
+++ b/classes/test/NioFilesPaths.java
@@ -126,6 +126,7 @@ class NioFilesPaths {
       System.out.println("Does tempDir/tempDir exist?: " + Files.exists(p));
       System.out.println("Making tempDir/tempDir : " + Files.createDirectories(p));
       System.out.println("Does tempDir/tempDir exist now?: " + Files.exists(p));
+      System.out.println("Does tempDir exist now?: " + Files.exists(p2));
       try {
         System.out.println("Deleting tempDir (should fail -- nonempty): " + Files.deleteIfExists(p2));
       } catch (final DirectoryNotEmptyException dne) {

--- a/classes/test/NioFilesPaths.java
+++ b/classes/test/NioFilesPaths.java
@@ -1,0 +1,178 @@
+package classes.test;
+
+import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
+
+class NioFilesPaths {
+  static void printFile(Path fPath) throws IOException {
+    Files.lines(fPath).forEach(System.out::println);
+  }
+
+  private static FileSystem dfs = FileSystems.getDefault();
+
+  public static void main(String[] args) throws IOException {
+    final String testDir = "./classes/test/data/FileOps";
+    final Path testDirPath = Paths.get("./classes/test/data/FileOps");
+    // I like scopes.
+    {
+      // This file does not exist.
+      final File f = Paths.get("/dfsd/dsfds").toFile();
+      try {
+        BufferedReader reader = new BufferedReader(new FileReader(f));
+      } catch (Exception e) {
+        System.out.println("Successfully threw exception for nonexistent file.");
+      }
+    }
+    {
+      Path p = Paths.get("");
+      System.out.println("Is '' an absolute path?: " + p.isAbsolute());
+      {
+        Path pAbs = p.toAbsolutePath();
+        Path pReal = p.toRealPath();
+        System.out.println("Real path:" + pReal);
+        System.out.println("Does the absolute path of '' exist?: " + Files.exists(pAbs));
+        System.out.println("Does the canonical path of '' exist?: " + Files.exists(pReal));
+        System.out.println("Does abspath == real.abspath?: " + (pAbs == pReal.toAbsolutePath()));
+        System.out.println("Does abspath.real == realpath?: " + (pAbs.toRealPath() == pReal));
+      }
+      System.out.println("Does '' exist?: " + Files.exists(p));
+      System.out.println("What is the length of ''?: " + Files.size(p));
+      System.out.println("Can you write to ''?: " + Files.isWritable(p));
+    }
+
+    final Path[] children = Files.list(testDirPath).toArray(Path[]::new);
+    // Sort by name to avoid nondeterministic file orderings.
+    Arrays.sort(children);
+    for (final Path child : children) {
+      System.out.println("["+child+"]");
+    }
+
+    {
+      final Path p = testDirPath.resolve("contains_data.txt");
+      System.out.println("Does contains_data.txt exist?: " + Files.exists(p));
+      System.out.println("Length of contains_data.txt: " + Files.size(p));
+    }
+
+    {
+      final Path p = Paths.get("/tmp");
+      System.out.println("Is /tmp a directory?: " + Files.isDirectory(p));
+      System.out.println("Can I write to it?: " + Files.isWritable(p));
+    }
+
+    {
+      final Path p = Paths.get("/tmp", "temp_delete_me.txt");
+      System.out.println("Does temp_delete_me.txt exist?: " + Files.exists(p));
+      /* File creation fails currently because channels not yet implemented
+      System.out.println("Did we successfully create this file?: " + Files.createFile(p));
+      System.out.println("And does it exist now?: " + Files.exists(p));
+      final long lm = Files.getLastModifiedTime(p).toMillis();
+      System.out.println("Can I write to it?: " + Files.isWritable(p));
+      // BrowserFS doesn't implement chmod anymore for the temporary file system.
+      // f.setWritable(false);
+      // System.out.println("How about now?: " + f.canWrite());
+      // f.setWritable(true);
+      // System.out.println("And now?: " + f.canWrite());
+      System.out.println("File size: " + Files.size(p));
+
+      // write over empty file
+      BufferedWriter bfw = Files.newBufferedWriter(p);
+      bfw.write("Why, hello there!\n");
+      bfw.close();
+
+      // mtime is platform-specific and not guaranteed to update
+      Files.setLastModifiedTime(p, FileTime.fromMillis(System.currentTimeMillis()+1337));  // padding for fast execution
+      System.out.println("Last modified updated?: " + (Files.getLastModifiedTime(p).toMillis() > lm));
+      System.out.println("New file size: " + Files.size(p));
+      System.out.println("File contents:");
+      printFile(p);
+      // append a line
+      System.out.println("Appending to file's end...");
+      final BufferedWriter bfw2 = Files.newBufferedWriter(p, StandardOpenOption.APPEND);
+      bfw2.write("A second line");
+      bfw2.close();
+
+      System.out.println("New file size: " + Files.size(p));
+      System.out.println("File contents:");
+      printFile(p);
+
+      // overwrite some text
+      System.out.println("Overwriting some text...");
+      RandomAccessFile raf = new RandomAccessFile(f, "rw");
+      raf.skipBytes(17);
+      raf.writeChars("KILROY WAS HERE\n");
+      raf.close();
+      System.out.println("File size: " + f.length());
+      System.out.println("File contents:");
+      printFile(f);
+      System.out.println("Deleting file: " + Files.deleteIfExists(p));
+      System.out.println("Does the file exist?: " + Files.exists(p));
+      */
+    }
+
+    // Create and delete a directory.
+    {
+      Path p = Paths.get("/tmp","tempDir");
+      System.out.println("Does tempDir exist?: " + Files.exists(p));
+      System.out.println("Making tempDir: " + Files.createDirectory(p));
+      System.out.println("Does tempDir exist now?: " + Files.exists(p));
+      System.out.println("Deleting tempDir: " + Files.deleteIfExists(p));
+      System.out.println("Does tempDir exist now?: " + Files.exists(p));
+    }
+    {
+      Path p = Paths.get("/tmp", "tempDir/tempDir");
+      Path p2 = Paths.get("/tmp", "tempDir");
+      System.out.println("Does tempDir/tempDir exist?: " + Files.exists(p));
+      System.out.println("Making tempDir/tempDir : " + Files.createDirectories(p));
+      System.out.println("Does tempDir/tempDir exist now?: " + Files.exists(p));
+      try {
+        System.out.println("Deleting tempDir (should fail -- nonempty): " + Files.deleteIfExists(p2));
+      } catch (final DirectoryNotEmptyException dne) {
+        System.out.println("Couldn't delete non-empty directory");
+      }
+      System.out.println("Deleting tempDir/tempDir: " + Files.deleteIfExists(p));
+      System.out.println("Deleting tempDir: " + Files.deleteIfExists(p2));
+      System.out.println("Does tempDir/tempDir exist now?: " + Files.exists(p));
+      System.out.println("Does tempDir exist now?: " + Files.exists(p2));
+    }
+
+    {
+      final Path p = Paths.get("/tmp");
+      try {
+        System.out.println("Trying to create a directory that already exists: " + Files.createDirectory(p));
+      } catch (final FileAlreadyExistsException fae) {
+        System.out.println("couldn't create a directory that already exists");
+      }
+    }
+
+    /*
+    // Rename a file.
+    {
+      File f = new File("/tmp/temp_rename_file.txt");
+      File f2 = new File("/tmp/temp_rename_file2.txt");
+      System.out.println("Creating temp_rename_file.txt: " + f.createNewFile());
+      System.out.println("Renaming it to temp_rename_file2.txt: " + f.renameTo(f2));
+      System.out.println("Old file exist? " + f.exists() + " New file exists? " + f2.exists());
+      System.out.println("Recreating old file: " + f.createNewFile());
+      System.out.println("Moving on top of old file: " + f2.renameTo(f));
+      System.out.println("Deleting old file: " + f.delete());
+      System.out.println("Trying to move nonexistant old file: " + f.renameTo(f2));
+    }
+
+    // Read only.
+    {
+      File f = new File("/tmp/temp_readonly.txt");
+      System.out.println("Creating temp_readonly.txt: " + f.createNewFile());
+      // BrowserFS doesn't support chmod in its temporary file system anymore.
+      // System.out.println("Marking as read only: " + f.setReadOnly());
+      System.out.println("Can I write to the file?: " + f.canWrite());
+      System.out.println("Can I read the file?: " + f.canRead());
+      // make sure we can open a read-only file with RandomAccessFile
+      RandomAccessFile raf = new RandomAccessFile(f, "r");
+      System.out.println("Deleting file: " + f.delete());
+    }
+    */
+
+  }
+}

--- a/classes/test/NioFilesPaths.java
+++ b/classes/test/NioFilesPaths.java
@@ -30,12 +30,12 @@ class NioFilesPaths {
       System.out.println("Is '' an absolute path?: " + p.isAbsolute());
       {
         Path pAbs = p.toAbsolutePath();
-        Path pReal = p.toRealPath();
-        System.out.println("Real path:" + pReal);
+        Path pNorm = p.normalize();
+        System.out.println("Real path:" + pNorm);
         System.out.println("Does the absolute path of '' exist?: " + Files.exists(pAbs));
-        System.out.println("Does the canonical path of '' exist?: " + Files.exists(pReal));
-        System.out.println("Does abspath == real.abspath?: " + (pAbs == pReal.toAbsolutePath()));
-        System.out.println("Does abspath.real == realpath?: " + (pAbs.toRealPath() == pReal));
+        System.out.println("Does the normalized path of '' exist?: " + Files.exists(pNorm));
+        System.out.println("Does abspath == norm.abspath?: " + (pAbs == pNorm.toAbsolutePath()));
+        System.out.println("Does abspath.real == normalized path?: " + (pAbs.toRealPath() == pNorm));
       }
       System.out.println("Does '' exist?: " + Files.exists(p));
       System.out.println("What is the length of ''?: " + Files.size(p));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-merge-source-maps": "^0.1.0",
     "grunt-ts": "^5.2.0",
     "jasmine-core": "^2.3.4",
-    "karma": "^0.13.9",
+    "karma": "^0.13.19",
     "karma-browserify": "^4.4.0",
     "karma-chrome-launcher": "^0.2.1",
     "karma-firefox-launcher": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typings": "dist/typings/src/doppiojvm",
   "dependencies": {
     "async": "^1.4.2",
-    "browserfs": "^0.5.10",
+    "browserfs": "^0.5.11",
     "glob": "^5.0.14",
     "gunzip-maybe": "^1.2.1",
     "optimist": "~0.6",

--- a/src/natives/sun_misc.ts
+++ b/src/natives/sun_misc.ts
@@ -375,10 +375,11 @@ class sun_misc_Unsafe {
     } else if (srcBase !== null && destBase === null) {
       // srcBase is an array, destOffset is an address where the contents of srcBase should be copied.
       if (util.is_array_type(srcBase.getClass().getInternalName()) && util.is_primitive_type((<ArrayClassData<any>> srcBase.getClass()).getComponentClass().getInternalName())) {
-        var srcArray: JVMTypes.JVMArray<any> = <any> srcBase, i: number;
+        const srcArray: JVMTypes.JVMArray<any> = <any> srcBase;
         switch (srcArray.getClass().getComponentClass().getInternalName()) {
           case 'B':
-            for (i = 0; i < length; i++) {
+          case 'C':
+            for (let i = 0; i < length; i++) {
               heap.set_signed_byte(destAddr + i, srcArray.array[srcAddr + i]);
             }
             break;

--- a/src/natives/sun_misc.ts
+++ b/src/natives/sun_misc.ts
@@ -331,7 +331,7 @@ class sun_misc_Unsafe {
    * @since 1.7
    */
   public static 'copyMemory(Ljava/lang/Object;JLjava/lang/Object;JJ)V'(thread: JVMThread, javaThis: JVMTypes.sun_misc_Unsafe, srcBase: JVMTypes.java_lang_Object, srcOffset: Long, destBase: JVMTypes.java_lang_Object, destOffset: Long, bytes: Long): void {
-    var heap = thread.getJVM().getHeap(),
+    const heap = thread.getJVM().getHeap(),
       srcAddr = srcOffset.toNumber(),
       destAddr = destOffset.toNumber(),
       length = bytes.toNumber();
@@ -342,10 +342,10 @@ class sun_misc_Unsafe {
       // OK, so... destBase is an array, destOffset is a byte offset from the
       // start of the array. Need to copy data from the heap directly into the array.
       if (util.is_array_type(destBase.getClass().getInternalName()) && util.is_primitive_type((<ArrayClassData<any>> destBase.getClass()).getComponentClass().getInternalName())) {
-        var destArray: JVMTypes.JVMArray<any> = <any> destBase, i: number;
+        const destArray: JVMTypes.JVMArray<any> = <any> destBase;
         switch (destArray.getClass().getComponentClass().getInternalName()) {
           case 'B':
-            for (i = 0; i < length; i++) {
+            for (let i = 0; i < length; i++) {
               destArray.array[destAddr + i] = heap.get_signed_byte(srcAddr + i);
             }
             break;
@@ -365,7 +365,7 @@ class sun_misc_Unsafe {
             break;*/
           default:
             // I have no idea what the appropriate semantics are for this.
-            thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented.');
+            thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented. destArray type: ' + destArray.getClass().getComponentClass().getInternalName());
             break;
         }
       } else {
@@ -384,7 +384,7 @@ class sun_misc_Unsafe {
             break;
           default:
             // I have no idea what the appropriate semantics are for this.
-            thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented.');
+            thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented. srcArray:' + srcArray.getClass().getComponentClass().getInternalName());
             break;
         }
       } else {
@@ -393,7 +393,7 @@ class sun_misc_Unsafe {
       }
     } else {
       // I have no idea what the appropriate semantics are for this.
-      thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented.');
+      thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented. Both src and dest are arrays?');
     }
   }
 

--- a/src/natives/sun_nio.ts
+++ b/src/natives/sun_nio.ts
@@ -619,7 +619,9 @@ class sun_nio_fs_UnixNativeDispatcher {
     thread.setStatus(ThreadStatus.ASYNC_WAITING);
     // TODO: Need to check specific flags
     const pathString = getStringFromHeap(thread, pathAddress);
-    fs.access(pathString, (err) => {
+    // TODO: fs.access() is better but not currently supported in browserfs: https://github.com/jvilk/BrowserFS/issues/128
+    const checker = util.are_in_browser() ? fs.stat : fs.access;
+    checker(pathString, (err, stat) => {
       if (err) {
         throwNodeError(thread, err);
       } else {

--- a/src/natives/sun_nio.ts
+++ b/src/natives/sun_nio.ts
@@ -479,9 +479,15 @@ class sun_nio_fs_UnixNativeDispatcher {
     });
   }
 
-  public static 'realpath0(J)[B'(thread: JVMThread, arg0: Long): JVMTypes.JVMArray<number> {
-    thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented.');
-    return null;
+  public static 'realpath0(J)[B'(thread: JVMThread, pathAddress: Long): void {
+    thread.setStatus(ThreadStatus.ASYNC_WAITING);
+    fs.realpath(getStringFromHeap(thread, pathAddress), (err, resolvedPath) => {
+      if (err) {
+        throwNodeError(thread, err);
+      } else {
+        thread.asyncReturn(util.initCarr(thread.getBsCl(), resolvedPath));
+      }
+    });
   }
 
   public static 'symlink0(JJ)V'(thread: JVMThread, arg0: Long, arg1: Long): void {
@@ -609,8 +615,17 @@ class sun_nio_fs_UnixNativeDispatcher {
     });
   }
 
-  public static 'access0(JI)V'(thread: JVMThread, arg0: Long, arg1: number): void {
-    thread.throwNewException('Ljava/lang/UnsatisfiedLinkError;', 'Native method not implemented.');
+  public static 'access0(JI)V'(thread: JVMThread, pathAddress: Long, arg1: number): void {
+    thread.setStatus(ThreadStatus.ASYNC_WAITING);
+    // TODO: Need to check specific flags
+    const pathString = getStringFromHeap(thread, pathAddress);
+    fs.access(pathString, (err) => {
+      if (err) {
+        throwNodeError(thread, err);
+      } else {
+        thread.asyncReturn();
+      }
+    });
   }
 
   public static 'getpwuid(I)[B'(thread: JVMThread, arg0: number): JVMTypes.JVMArray<number> {

--- a/src/natives/sun_nio.ts
+++ b/src/natives/sun_nio.ts
@@ -197,13 +197,11 @@ function stringToByteArray(thread: JVMThread, str: string): JVMTypes.JVMArray<nu
     return null;
   }
 
-  var buff = new Buffer(str, 'utf8'), len = buff.length,
-    arr = util.newArray<number>(thread, thread.getBsCl(), '[B', len + 1),
-    i: number;
-  for (i = 0; i < len; i++) {
+  const buff = new Buffer(str, 'utf8'), len = buff.length,
+    arr = util.newArray<number>(thread, thread.getBsCl(), '[B', len);
+  for (let i = 0; i < len; i++) {
     arr.array[i] = buff.readUInt8(i);
   }
-  arr.array[len] = 0;
   return arr;
 }
 


### PR DESCRIPTION
Things which this PR fixes:
* Path.toRealPath()
* Files.exists()
* Files.createDirectory(), Files.createDirectories()
* Files.list() (this was failing because of a bug in string conversion)

Note that the implementation of `access0` is not complete. It needs to consider the type-of-access.

Also, file creation with NIO API doesn't work yet, because file channels have not been implemented.

For #403.