### PR TITLE
Use the async constructor of ZipFS...

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typings": "dist/typings/src/doppiojvm",
   "dependencies": {
     "async": "^1.5.2",
-    "browserfs": "^0.5.11",
+    "browserfs": "^0.5.12",
     "glob": "^6.0.4",
     "gunzip-maybe": "^1.3.1",
     "karma": "^0.13.19",

--- a/src/ClassLoader.ts
+++ b/src/ClassLoader.ts
@@ -375,7 +375,10 @@ export class BootstrapClassLoader extends ClassLoader {
    *   Passes an error if one occurs.
    */
   constructor(javaHome: string, classpath: string[], cb: (e?: any) => void) {
-    super(this);
+    // The correct way to do this would be super(this), but we cannot reference this before calling super()
+    super(null);
+    this.bootstrap = this;
+
     this.classpath = null;
     this.loadedPackages = {};
 

--- a/src/classpath.ts
+++ b/src/classpath.ts
@@ -94,9 +94,16 @@ export abstract class AbstractClasspathJar {
           cb(e);
         } else {
           try {
-            this._fs.initialize(new ZipFS(data, path.basename(this._path)));
-            this._jarRead = TriState.TRUE;
-            cb();
+            ZipFS.computeIndex(data, (index) => {
+              try {
+                this._fs.initialize(new ZipFS(index, path.basename(this._path)));
+                this._jarRead = TriState.TRUE;
+                cb();
+              } catch (e) {
+                this._jarRead = TriState.FALSE;
+                cb(e);
+              }
+            });
           } catch (e) {
             this._jarRead = TriState.FALSE;
             cb(e);

--- a/src/natives/sun_nio.ts
+++ b/src/natives/sun_nio.ts
@@ -307,7 +307,6 @@ function flag2nodeflag(thread: JVMThread, flag: number): string {
       // 'w+' - Open file for reading and writing. The file is created (if it does not exist) or truncated (if it exists).
       // 'wx+' - Like 'w+' but fails if path exists.
       return failIfExists ? 'wx+' : 'w+';
-      return 'wx+';
     } else {
       // 'r+' - Open file for reading and writing. An exception occurs if the file does not exist.
       // 'rs+' - Open file for reading and writing, telling the OS to open it synchronously.


### PR DESCRIPTION
.. from the latest version of BrowserFS. This improves responsiveness when loading large jars.