### PR TITLE
API to release JVM resources

### DIFF
--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -766,6 +766,20 @@ eval(mod);
   public dumpState(filename: string, cb: (er: any) => void): void {
     fs.appendFile(filename, this.threadPool.getThreads().map((t: JVMThread) => `Thread ${t.getRef()}:\n` + t.getPrintableStackTrace()).join("\n\n"), cb);
   }
+
+  /**
+   * Releases all resources held by this JVM instance
+   */
+  public close() {
+    this.heap = null;
+    this.bsCl = null;
+    this.systemProperties = null;
+    this.internedStrings = null;
+    this.threadPool = null;
+    this.natives = null;
+    this.nativeClasspath = null;
+    this.firstThread = null;
+  }
 }
 
 export = JVM;


### PR DESCRIPTION
This API might be useful for long running apps (but see question below).

Before closing() the JS heap size is about 250 MB. After closing(), it becomes 10MB (most of this residual 10MB is browser native data, such as JIT compiled JS code, etc).

----
Question:
Is the JVM instance automatically retained by doppio in some global context. Ideally, the close() API shouldn't be required, because when the JVM instance becomes unreachable, the resources it holds should also become unreachable.