### PR TITLE
hand optimised methods

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -19,11 +19,11 @@ declare var RELEASE: boolean;
 if (typeof RELEASE === 'undefined') global.RELEASE = false;
 
 var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } = {
-  'java/lang/ref/Reference': {
+  'Ljava/lang/ref/Reference;': {
     // NOP, because we don't do our own GC and also this starts a thread?!?!?!
     '<clinit>()V': function (thread: threading.JVMThread): void { }
   },
-  'java/lang/System': {
+  'Ljava/lang/System;': {
     'loadLibrary(Ljava/lang/String;)V': function (thread: threading.JVMThread, libName: JVMTypes.java_lang_String): void {
       // Some libraries test if native libraries are available,
       // and expect an exception if they are not.
@@ -43,19 +43,19 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
       }
     }
   },
-  'java/lang/Terminator': {
+  'Ljava/lang/Terminator;': {
     'setup()V': function (thread: threading.JVMThread): void {
       // XXX: We should probably fix this; we support threads now.
       // Historically: NOP'd because we didn't support threads.
     }
   },
-  'java/nio/charset/Charset$3': {
+  'Ljava/nio/charset/Charset$3;': {
     // this is trapped and NOP'ed for speed
     'run()Ljava/lang/Object;': function (thread: threading.JVMThread, javaThis: JVMTypes.java_nio_charset_Charset$3): JVMTypes.java_lang_Object {
       return null;
     }
   },
-  'sun/nio/fs/DefaultFileSystemProvider': {
+  'Lsun/nio/fs/DefaultFileSystemProvider;': {
     // OpenJDK doesn't know what the "Doppio" platform is. Tell it to use the Linux file system.
     'create()Ljava/nio/file/spi/FileSystemProvider;': function(thread: threading.JVMThread): void {
       thread.setStatus(enums.ThreadStatus.ASYNC_WAITING);
@@ -65,7 +65,7 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
     }
   },
 
-  'java/lang/Math': {
+  'Ljava/lang/Math;': {
     'min(II)I' : function(thread: threading.JVMThread, first: number, second: number): number {
       return first < second ? first : second;
     },
@@ -74,13 +74,13 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
     }
   },
 
-  'java/lang/Object': {
+  'Ljava/lang/Object;': {
     '<init>()V' : function(thread: threading.JVMThread): void {
       // NOP
     }
   },
 
-  'java/lang/String': {
+  'Ljava/lang/String;': {
     'length()I' : function(thread: threading.JVMThread, obj: JVMTypes.java_lang_String): number {
       const v1 = obj['java/lang/String/value'].array;
       return v1.length;
@@ -123,7 +123,7 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
     }
   },
 
-  'com/sun/tools/javac/file/ZipFileIndex': {
+  'Lcom/sun/tools/javac/file/ZipFileIndex;': {
      'access$400([BI)I' : function(thread: threading.JVMThread, bArray: JVMTypes.JVMArray<number>, index: number): number {
        const array: number[] = bArray.array;
        return (
@@ -143,7 +143,7 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
      }
   },
 
-  'com/sun/tools/javac/util/List': {
+  'Lcom/sun/tools/javac/util/List;': {
      'nonEmpty()Z' : function(thread: threading.JVMThread, obj: JVMTypes.java_util_List): number {
        return (<any>obj)['com/sun/tools/javac/util/List/tail'] === null ? 0 : 1;
      }
@@ -152,11 +152,11 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
 };
 
 function getTrappedMethod(clsName: string, methSig: string): Function {
-  clsName = util.descriptor2typestr(clsName);
-  if (trapped_methods.hasOwnProperty(clsName) && trapped_methods[clsName].hasOwnProperty(methSig)) {
-    return trapped_methods[clsName][methSig];
+  const trappedClass = trapped_methods[clsName];
+  if (trappedClass) {
+    return trappedClass[methSig];
   }
-  return null;
+  return undefined;
 }
 
 /**
@@ -359,8 +359,9 @@ export class Method extends AbstractMethodField {
 
     // Initialize 'code' property.
     var clsName = this.cls.getInternalName();
-    if (getTrappedMethod(clsName, this.signature) !== null) {
-      this.code = getTrappedMethod(clsName, this.signature);
+    const trappedMethod = getTrappedMethod(clsName, this.signature);
+    if (trappedMethod !== undefined) {
+      this.code = trappedMethod;
       this.accessFlags.setNative(true);
     } else if (this.accessFlags.isNative()) {
       if (this.signature.indexOf('registerNatives()V', 0) < 0 && this.signature.indexOf('initIDs()V', 0) < 0) {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -63,7 +63,92 @@ var trapped_methods: { [clsName: string]: { [methodName: string]: Function } } =
        dfspCls: typeof JVMTypes.sun_nio_fs_DefaultFileSystemProvider = <any> dfsp.getConstructor(thread);
       dfspCls['createProvider(Ljava/lang/String;)Ljava/nio/file/spi/FileSystemProvider;'](thread, [thread.getJVM().internString('sun.nio.fs.LinuxFileSystemProvider')], util.forwardResult(thread));
     }
+  },
+
+  'java/lang/Math': {
+    'min(II)I' : function(thread: threading.JVMThread, first: number, second: number): number {
+      return first < second ? first : second;
+    },
+    'abs(D)D' : function(thread: threading.JVMThread, value: number): number {
+      return value < 0 ? -value : value;
+    }
+  },
+
+  'java/lang/Object': {
+    '<init>()V' : function(thread: threading.JVMThread): void {
+      // NOP
+    }
+  },
+
+  'java/lang/String': {
+    'length()I' : function(thread: threading.JVMThread, obj: JVMTypes.java_lang_String): number {
+      const v1 = obj['java/lang/String/value'].array;
+      return v1.length;
+    },
+
+    'charAt(I)C' : function stringCharAt(thread: threading.JVMThread, obj: JVMTypes.java_lang_String, index: number): number {
+      if (index < 0) {
+        thread.throwNewException<JVMTypes.java_lang_Throwable>('Ljava/lang/StringIndexOutOfBoundsException;', ''+index);
+      } else {
+        const v1 = obj['java/lang/String/value'].array;
+        const len1 = v1.length;
+        if (index >= len1) {
+          thread.throwNewException<JVMTypes.java_lang_Throwable>('Ljava/lang/StringIndexOutOfBoundsException;', ''+index);
+        } else {
+          return v1[index];
+        }
+      }
+    },
+
+    'compareTo(Ljava/lang/String;)I' : function stringCompareTo(thread: threading.JVMThread, obj: JVMTypes.java_lang_String, otherString: JVMTypes.java_lang_String): number {
+      if (otherString == null) {
+        thread.throwNewException<JVMTypes.java_lang_Throwable>('Ljava/lang/NullPointerException;', '');
+      } else {
+        const v1 = obj['java/lang/String/value'].array;
+        const v2 = otherString['java/lang/String/value'].array;
+        const len1 = v1.length;
+        const len2 = v2.length;
+        const lim = Math.min(len1, len2);
+        let k = 0;
+        while (k < lim) {
+          const c1 = v1[k];
+          const c2 = v2[k];
+          if (c1 != c2) {
+            return c1 - c2;
+          }
+          k++;
+        }
+        return len1 - len2;
+      }
+    }
+  },
+
+  'com/sun/tools/javac/file/ZipFileIndex': {
+     'access$400([BI)I' : function(thread: threading.JVMThread, bArray: JVMTypes.JVMArray<number>, index: number): number {
+       const array: number[] = bArray.array;
+       return (
+         ((array[index    ] & 0xff)      ) |
+         ((array[index + 1] & 0xff) << 8 )
+       );
+     },
+
+     'access$500([BI)I' : function(thread: threading.JVMThread, bArray: JVMTypes.JVMArray<number>, index: number): number {
+       const array: number[] = bArray.array;
+       return (
+         ((array[index    ] & 0xff)      ) |
+         ((array[index + 1] & 0xff) << 8 ) |
+         ((array[index + 2] & 0xff) << 16) |
+         ((array[index + 3] & 0xff) << 24)
+       );
+     }
+  },
+
+  'com/sun/tools/javac/util/List': {
+     'nonEmpty()Z' : function(thread: threading.JVMThread, obj: JVMTypes.java_util_List): number {
+       return (<any>obj)['com/sun/tools/javac/util/List/tail'] === null ? 0 : 1;
+     }
   }
+
 };
 
 function getTrappedMethod(clsName: string, methSig: string): Function {


### PR DESCRIPTION
### Background
I am trying to design a simple JIT compiler for doppio. During analysis, I noticed that for [my benchmark](https://gist.github.com/hrj/94784fc6af4b49a112a0), the following methods were the most frequently called:

```
count of calls: method name
------------------------------------
161516: java/lang/Math/min(II)I
147661: java/lang/Object/<init>()V
113636: com/sun/tools/javac/file/ZipFileIndex/get4ByteLittleEndian([BI)I
113633: com/sun/tools/javac/file/ZipFileIndex/access$500([BI)I
90974: com/sun/tools/javac/file/ZipFileIndex/get2ByteLittleEndian([BI)I
90962: com/sun/tools/javac/file/ZipFileIndex/access$400([BI)I
84696: java/lang/String/compareTo(Ljava/lang/String;)I
83489: com/sun/tools/javac/file/ZipFileIndex$Entry/compareTo(Ljava/lang/Object;)I, com/sun/tools/javac/file/ZipFileIndex$Entry/compareTo(Lcom/sun/tools/javac/f
ile/ZipFileIndex$Entry;)I 
```
Implementing the JIT compiler will take some time, but I thought I would hand-compile the above methods for two reasons:
* To see how much performance benefit it fetches.
* Some of these methods are too complex for the first iteration of JIT that I am planning. They have loops and branches that will take a long time to JIT optimise.

### Changes
This PR adds some more "trapped methods" that help improve speed because they are implemented as native JS functions that use NativeStackFrame instead of interpreted methods with BytecodeStackFrame.

### Benchmark result

For the "compile" benchmark:

| Environment | Time before | Time after (improvement percent)  |
| ----------- | ---------- | ---------------------------------- |
| Chromium 48 |   26870    | 23327 (13.2)                       |
| Firefox 44  |   33796    | 29602 (11.6)                       |

