### PR TITLE
Dereference JVM instances after it terminates

### DIFF
--- a/src/threading.ts
+++ b/src/threading.ts
@@ -1143,6 +1143,10 @@ export class JVMThread implements Thread {
   public handleUncaughtException(exception: JVMTypes.java_lang_Throwable) {
     this.jvmThreadObj['dispatchUncaughtException(Ljava/lang/Throwable;)V'](this, [exception]);
   }
+
+  public close() {
+    this.jvm = null;
+  }
 }
 
 /**

--- a/src/threadpool.ts
+++ b/src/threadpool.ts
@@ -138,9 +138,9 @@ export default class ThreadPool<T extends Thread> {
    * Called when the ThreadPool becomes empty. This is usually a sign that
    * execution has finished.
    */
-  private emptyCallback: () => void;
+  private emptyCallback: () => boolean;
 
-  constructor(emptyCallback: () => void) {
+  constructor(emptyCallback: () => boolean) {
     this.emptyCallback = emptyCallback;
   }
 
@@ -180,7 +180,10 @@ export default class ThreadPool<T extends Thread> {
     this.threads.splice(idx, 1);
 
     if (!this.anyNonDaemonicThreads()) {
-      this.emptyCallback();
+      const close = this.emptyCallback();
+      if (close) {
+        this.emptyCallback = null;
+      }
     }
   }
 

--- a/src/threadpool.ts
+++ b/src/threadpool.ts
@@ -137,6 +137,8 @@ export default class ThreadPool<T extends Thread> {
   /**
    * Called when the ThreadPool becomes empty. This is usually a sign that
    * execution has finished.
+   *
+   * If the callback returns true it signals that this threadpool can free its resources.
    */
   private emptyCallback: () => boolean;
 


### PR DESCRIPTION
* the `emptyCallback()` retained a reference to the JVM through a chain of closures in `bootstrapTasks`. This is now nulled after the callback has been called and the JVM exits.
* The JVM retained a reference to firstThread which in turn kept a reference back to the JVM. Removing this back reference after the JVM terminates, releases the JVM instance to the GC.

This is better than #434, since minimal changes have been made, and the de-referencing is done automatically without the need for an explicit API.