### PR TITLE
JIT compiler, first cut

### DIFF
--- a/src/jit.ts
+++ b/src/jit.ts
@@ -899,6 +899,19 @@ thread.asyncReturn(${pops[1]}, null);
 table[OpCode.LRETURN] = return64;
 table[OpCode.DRETURN] = return64;
 
+table[OpCode.MONITOREXIT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if (${pops[0]}.getMonitor().exit(thread)) {
+frame.pc++;
+${onSuccess}
+} else {
+${onError}
+frame.returnToThreadLoop = true;
+}
+`;
+}};
+
 table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]} = ${pops[0]} ^ ${pops[1]};
@@ -1058,6 +1071,14 @@ if (${pops[1]}.isZero()) {
   frame.pc++;
   ${onSuccess}
 }`;
+}};
+
+table[OpCode.DREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[3]} % ${pops[1]};
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
 }};
 
 table[OpCode.INEG] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
@@ -1224,6 +1245,16 @@ table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushe
 var ${pushes[0]} = ${pops[0]};
 var ${pushes[1]} = ${pops[1]};
 var ${pushes[2]} = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]};
+var ${pushes[1]} = ${pops[2]};
+var ${pushes[2]} = ${pops[1]};
+var ${pushes[3]} = ${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -853,9 +853,7 @@ table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes
   return `
 frame.returnToThreadLoop = true;
 if (frame.method.accessFlags.isSynchronized()) {
-  // monitorexit
   if (!frame.method.methodLock(thread, frame).exit(thread)) {
-    // monitorexit threw an exception.
     return;
   }
 }
@@ -869,9 +867,7 @@ const return32: JitInfo = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pus
   return `
 frame.returnToThreadLoop = true;
 if (frame.method.accessFlags.isSynchronized()) {
-  // monitorexit
   if (!frame.method.methodLock(thread, frame).exit(thread)) {
-    // monitorexit threw an exception.
     return;
   }
 }
@@ -887,9 +883,7 @@ const return64: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pus
   return `
 frame.returnToThreadLoop = true;
 if (frame.method.accessFlags.isSynchronized()) {
-  // monitorexit
   if (!frame.method.methodLock(thread, frame).exit(thread)) {
-    // monitorexit threw an exception.
     return;
   }
 }
@@ -1172,8 +1166,6 @@ ${onSuccess}`;
 
 table[OpCode.I2F] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-// NOP; we represent ints as floats anyway.
-// @todo What about quantities unexpressable as floats?
 frame.pc++;
 ${onSuccess}`;
 }};

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -4,7 +4,7 @@ import enums = require('./enums');
 import opcodes = require('./opcodes');
 
 export interface JitInfo {
-  pops: number,
+  pops: number,                 // If negative, then it is treated a request rather than a demand
   pushes: number,
   hasBranch: boolean,
   emit: (pops: string[], pushes: string[], suffix: string, onSuccess: string, code: Buffer, pc: number, onErrorPushes: string[]) => string
@@ -795,35 +795,35 @@ ${onSuccess}`;
 
 table[OpCode.LCMP] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = ${pops[3]}.compare(${pops[1]});
+var ${pushes[0]} = ${pops[3]}.compare(${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FCMPL] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? -1 : 1);
+var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? -1 : 1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DCMPL] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? 1 : -1);
+var ${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? 1 : -1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FCMPG] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} < ${pops[0]} ? -1 : 1);
+var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} < ${pops[0]} ? -1 : 1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DCMPG] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} < ${pops[1]} ? -1 : 1);
+var ${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} < ${pops[1]} ? -1 : 1);
 frame.pc++;
 ${onSuccess}`;
 }};

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -384,9 +384,7 @@ f.pc+=3;${onSuccess}`;
 
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
-  return `
-if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}
-}else{${onError}}`;
+  return `if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}}else{${onError}}`;
 }};
 
 const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
@@ -693,8 +691,7 @@ table[OpCode.IUSHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes
 }};
 
 table[OpCode.LUSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
+  return `var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2B] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -11,7 +11,7 @@ export interface JitInfo {
 }
 
 function makeOnError(onErrorPushes: string[]) {
-  return onErrorPushes.length > 0 ? `frame.opStack.pushAll(${onErrorPushes.join(',')})` : '';
+  return onErrorPushes.length > 0 ? `f.opStack.pushAll(${onErrorPushes.join(',')})` : '';
 }
 
 export const opJitInfo: JitInfo[] = function() {
@@ -35,42 +35,42 @@ const OpCode = enums.OpCode;
 table[OpCode.ACONST_NULL] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ICONST_M1] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=-1;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[0];
-frame.pc++;
+var ${pushes[0]}=f.locals[0];
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[1];
-frame.pc++;
+var ${pushes[0]}=f.locals[1];
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[2];
-frame.pc++;
+var ${pushes[0]}=f.locals[2];
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load3_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[3];
-frame.pc++;
+var ${pushes[0]}=f.locals[3];
+f.pc++;
 ${onSuccess}`;
 }};
 
@@ -92,29 +92,29 @@ table[OpCode.FLOAD_3] = load3_32;
 
 const load0_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[0],${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=f.locals[0],${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load1_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[1],${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=f.locals[1],${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load2_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[2],${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=f.locals[2],${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
 const load3_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=frame.locals[3],${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=f.locals[3],${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
@@ -132,29 +132,29 @@ table[OpCode.DLOAD_3] = load3_64;
 
 const store0_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[0]=${pops[0]};
-frame.pc++;
+f.locals[0]=${pops[0]};
+f.pc++;
 ${onSuccess}`;
 }}
 
 const store1_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[1]=${pops[0]};
-frame.pc++;
+f.locals[1]=${pops[0]};
+f.pc++;
 ${onSuccess}`;
 }}
 
 const store2_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[2]=${pops[0]};
-frame.pc++;
+f.locals[2]=${pops[0]};
+f.pc++;
 ${onSuccess}`;
 }}
 
 const store3_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[3]=${pops[0]};
-frame.pc++;
+f.locals[3]=${pops[0]};
+f.pc++;
 ${onSuccess}`;
 }}
 
@@ -177,41 +177,41 @@ table[OpCode.FSTORE_3] = store3_32;
 const store_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readUInt8(pc + 1);
   return `
-frame.locals[${offset+1}]=${pops[0]};
-frame.locals[${offset}]=${pops[1]};
-frame.pc+=2;
+f.locals[${offset+1}]=${pops[0]};
+f.locals[${offset}]=${pops[1]};
+f.pc+=2;
 ${onSuccess}`;
 }}
 
 const store0_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[1]=${pops[0]};
-frame.locals[0]=${pops[1]};
-frame.pc++;
+f.locals[1]=${pops[0]};
+f.locals[0]=${pops[1]};
+f.pc++;
 ${onSuccess}`;
 }}
 
 const store1_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[2]=${pops[0]};
-frame.locals[1]=${pops[1]};
-frame.pc++;
+f.locals[2]=${pops[0]};
+f.locals[1]=${pops[1]};
+f.pc++;
 ${onSuccess}`;
 }}
 
 const store2_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[3]=${pops[0]};
-frame.locals[2]=${pops[1]};
-frame.pc++;
+f.locals[3]=${pops[0]};
+f.locals[2]=${pops[1]};
+f.pc++;
 ${onSuccess}`;
 }}
 
 const store3_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[4]=${pops[0]};
-frame.locals[3]=${pops[1]};
-frame.pc++;
+f.locals[4]=${pops[0]};
+f.locals[3]=${pops[1]};
+f.pc++;
 ${onSuccess}`;
 }}
 
@@ -233,19 +233,19 @@ table[OpCode.DSTORE_3] = store3_64;
 const const0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=0;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 const const1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=1;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 const const2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=2;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 
@@ -261,49 +261,49 @@ table[OpCode.FCONST_2] = const2_32;
 table[OpCode.ICONST_3] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=3;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.ICONST_4] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=4;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.ICONST_5] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=5;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.LCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=util.gLong.ZERO,${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=u.gLong.ZERO,${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.LCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=util.gLong.ONE,${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=u.gLong.ONE,${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.DCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=0,${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=1,${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }}
 
@@ -312,14 +312,14 @@ const aload32: JitInfo = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pus
   return `
 var idx${suffix}=${pops[0]},
 obj${suffix}=${pops[1]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
 }else{
 var ${pushes[0]}=obj${suffix}.array[idx${suffix}];
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }
 }else{
@@ -340,14 +340,14 @@ const aload64: JitInfo = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pus
   return `
 var idx${suffix}=${pops[0]},
 obj${suffix}=${pops[1]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
 }else{
 var ${pushes[0]}=obj${suffix}.array[idx${suffix}],${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }
 }else{
@@ -365,14 +365,14 @@ const astore32: JitInfo = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pu
 var val${suffix}=${pops[0]},
 idx${suffix}=${pops[1]},
 obj${suffix}=${pops[2]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
 }else{
 obj${suffix}.array[idx${suffix}]=val${suffix};
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }
 }else{
@@ -394,14 +394,14 @@ const astore64: JitInfo = {hasBranch: false, pops: 4, pushes: 0, emit: (pops, pu
 var val${suffix}=${pops[1]},
 idx${suffix}=${pops[2]},
 obj${suffix}=${pops[3]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
 }else{
 obj${suffix}.array[idx${suffix}]=val${suffix};
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }
 }else{
@@ -418,14 +418,14 @@ table[OpCode.LDC] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, 
   const index = code.readUInt8(pc + 1);
   const onError = makeOnError(onErrorPushes);
   return `
-var constant${suffix}=frame.method.cls.constantPool.get(${index});
+var constant${suffix}=f.method.cls.constantPool.get(${index});
 if(constant${suffix}.isResolved()){
-var ${pushes[0]}=constant${suffix}.getConstant(thread);
-frame.pc+=2;
+var ${pushes[0]}=constant${suffix}.getConstant(t);
+f.pc+=2;
 ${onSuccess}
 }else{
 ${onError}
-util.resolveCPItem(thread,frame,constant${suffix});
+u.resolveCPItem(t,f,constant${suffix});
 }`;
 }};
 
@@ -434,14 +434,14 @@ table[OpCode.LDC_W] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes
   const index = code.readUInt16BE(pc + 1);
   const onError = makeOnError(onErrorPushes);
   return `
-var constant${suffix}=frame.method.cls.constantPool.get(${index});
+var constant${suffix}=f.method.cls.constantPool.get(${index});
 if(constant${suffix}.isResolved()){
-var ${pushes[0]}=constant${suffix}.getConstant(thread);
-frame.pc+=3;
+var ${pushes[0]}=constant${suffix}.getConstant(t);
+f.pc+=3;
 ${onSuccess}
 }else{
 ${onError}
-util.resolveCPItem(thread,frame,constant${suffix});
+u.resolveCPItem(t,f,constant${suffix});
 }`;
 }};
 
@@ -449,9 +449,9 @@ util.resolveCPItem(thread,frame,constant${suffix});
 table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var constant${suffix}=frame.method.cls.constantPool.get(${index});
+var constant${suffix}=f.method.cls.constantPool.get(${index});
 var ${pushes[0]}=constant${suffix}.value,${pushes[1]}=null;
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -459,9 +459,9 @@ ${onSuccess}`;
 table[OpCode.GETSTATIC_FAST32] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
 ${pushes[0]}=fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -469,10 +469,10 @@ ${onSuccess}`;
 table[OpCode.GETSTATIC_FAST64] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
 ${pushes[0]}=fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName],
 ${pushes[1]}=null;
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -481,11 +481,11 @@ table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
 obj${suffix}=${pops[0]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName];
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}
 }else{
 ${onError}
@@ -497,11 +497,11 @@ table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
 obj${suffix}=${pops[0]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName],${pushes[1]}=null;
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}
 }else{
 ${onError}
@@ -513,11 +513,11 @@ table[OpCode.PUTFIELD_FAST32] = {hasBranch: false, pops: 2, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
 obj${suffix}=${pops[1]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[0]};
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}
 }else{
 ${onError}
@@ -529,11 +529,11 @@ table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
 obj${suffix}=${pops[2]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[1]};
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}
 }else{
 ${onError}
@@ -544,10 +544,10 @@ ${onError}
 table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var cls${suffix}=frame.method.cls.constantPool.get(${index}).cls,
+var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,
 o${suffix}=${pops[0]},
 ${pushes[0]}=o${suffix}!==null?(o${suffix}.getClass().isCastable(cls${suffix})?1:0):0;
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -555,9 +555,9 @@ table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, 
   const onError = makeOnError(onErrorPushes);
   return `
 var obj${suffix}=${pops[0]};
-if(!util.isNull(thread,frame,obj${suffix})){
+if(!u.isNull(t,f,obj${suffix})){
 var ${pushes[0]}=obj${suffix}.array.length;
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }else{
 ${onError}
@@ -567,8 +567,8 @@ ${onError}
 const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-var ${pushes[0]}=frame.locals[${index}];
-frame.pc+=2;
+var ${pushes[0]}=f.locals[${index}];
+f.pc+=2;
 ${onSuccess}`;
 }}
 
@@ -579,8 +579,8 @@ table[OpCode.FLOAD] = load32;
 const load64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-var ${pushes[0]}=frame.locals[${index}],${pushes[1]}=null;
-frame.pc+=2;
+var ${pushes[0]}=f.locals[${index}],${pushes[1]}=null;
+f.pc+=2;
 ${onSuccess}`;
 }}
 
@@ -590,8 +590,8 @@ table[OpCode.DLOAD] = load64;
 const store32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-frame.locals[${index}]=${pops[0]};
-frame.pc+=2;
+f.locals[${index}]=${pops[0]};
+f.pc+=2;
 ${onSuccess}`;
 }}
 
@@ -603,7 +603,7 @@ table[OpCode.BIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushe
   const value = code.readInt8(pc + 1);
   return `
 var ${pushes[0]}=${value};
-frame.pc+=2;
+f.pc+=2;
 ${onSuccess}`;
 }};
 
@@ -611,7 +611,7 @@ table[OpCode.SIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushe
   const value = code.readInt16BE(pc + 1);
   return `
 var ${pushes[0]}=${value};
-frame.pc+=3;
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -619,8 +619,8 @@ table[OpCode.IINC] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes,
   const idx = code.readUInt8(pc + 1);
   const val = code.readInt8(pc + 2);
   return `
-frame.locals[${idx}]=(frame.locals[${idx}]+${val})|0;
-frame.pc+=3;
+f.locals[${idx}]=(f.locals[${idx}]+${val})|0;
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -629,14 +629,14 @@ table[OpCode.ATHROW] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes
   const onError = makeOnError(onErrorPushes);
   return `
 ${onError}
-thread.throwException(${pops[0]});
-frame.returnToThreadLoop=true;`;
+t.throwException(${pops[0]});
+f.returnToThreadLoop=true;`;
 }};
 
 table[OpCode.GOTO] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-frame.pc+=${offset};
+f.pc+=${offset};
 ${onSuccess}`;
 }};
 
@@ -644,9 +644,9 @@ const cmpeq: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}===${pops[1]}){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -658,9 +658,9 @@ const cmpne: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}!==${pops[1]}){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -672,9 +672,9 @@ table[OpCode.IF_ICMPGE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pus
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[1]}>=${pops[0]}){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -683,9 +683,9 @@ table[OpCode.IF_ICMPGT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pus
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[1]}>${pops[0]}){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -694,9 +694,9 @@ table[OpCode.IF_ICMPLE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pus
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[1]}<=${pops[0]}){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -705,9 +705,9 @@ table[OpCode.IF_ICMPLT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pus
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[1]}<${pops[0]}){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -716,9 +716,9 @@ table[OpCode.IFNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}==null){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -727,9 +727,9 @@ table[OpCode.IFNONNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pus
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}!=null){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -738,9 +738,9 @@ table[OpCode.IFEQ] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, 
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}===0){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -749,9 +749,9 @@ table[OpCode.IFNE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, 
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}!==0){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -760,9 +760,9 @@ table[OpCode.IFGT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, 
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}>0){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -771,9 +771,9 @@ table[OpCode.IFLT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, 
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}<0){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -782,9 +782,9 @@ table[OpCode.IFGE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, 
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}>=0){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -793,9 +793,9 @@ table[OpCode.IFLE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, 
   const offset = code.readInt16BE(pc + 1);
   return `
 if(${pops[0]}<=0){
-frame.pc+=${offset};
+f.pc+=${offset};
 }else{
-frame.pc+=3;
+f.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -803,35 +803,35 @@ ${onSuccess}`;
 table[OpCode.LCMP] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}.compare(${pops[1]});
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FCMPL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}>${pops[0]}?1:-1);
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DCMPL] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}>${pops[1]}?1:-1);
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FCMPG] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}<${pops[0]}?-1:1);
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DCMPG] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}<${pops[1]}?-1:1);
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
@@ -839,13 +839,13 @@ table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes
   // TODO: check flags at JIT time
   // TODO: on error pushes
   return `
-frame.returnToThreadLoop=true;
-if(frame.method.accessFlags.isSynchronized()){
-if(!frame.method.methodLock(thread,frame).exit(thread)){
+f.returnToThreadLoop=true;
+if(f.method.accessFlags.isSynchronized()){
+if(!f.method.methodLock(t,f).exit(t)){
  return;
 }
 }
-thread.asyncReturn();
+t.asyncReturn();
 `;
 }};
 
@@ -853,9 +853,9 @@ const return32: JitInfo = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pus
   // TODO: check flags at JIT time
   // TODO: on error pushes
   return `
-frame.returnToThreadLoop=true;
-if(frame.method.accessFlags.isSynchronized()){if(!frame.method.methodLock(thread,frame).exit(thread)){return;}}
-thread.asyncReturn(${pops[0]});
+f.returnToThreadLoop=true;
+if(f.method.accessFlags.isSynchronized()){if(!f.method.methodLock(t,f).exit(t)){return;}}
+t.asyncReturn(${pops[0]});
 `;
 }};
 table[OpCode.IRETURN] = return32;
@@ -865,9 +865,9 @@ table[OpCode.ARETURN] = return32;
 const return64: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix) => {
   // TODO: check flags at JIT time
   return `
-frame.returnToThreadLoop=true;
-if(frame.method.accessFlags.isSynchronized()){if(!frame.method.methodLock(thread,frame).exit(thread)){return;}}
-thread.asyncReturn(${pops[1]},null);
+f.returnToThreadLoop=true;
+if(f.method.accessFlags.isSynchronized()){if(!f.method.methodLock(t,f).exit(t)){return;}}
+t.asyncReturn(${pops[1]},null);
 `;
 }};
 table[OpCode.LRETURN] = return64;
@@ -876,12 +876,12 @@ table[OpCode.DRETURN] = return64;
 table[OpCode.MONITOREXIT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-if(${pops[0]}.getMonitor().exit(thread)){
-frame.pc++;
+if(${pops[0]}.getMonitor().exit(t)){
+f.pc++;
 ${onSuccess}
 }else{
 ${onError}
-frame.returnToThreadLoop=true;
+f.returnToThreadLoop=true;
 }
 `;
 }};
@@ -889,84 +889,84 @@ frame.returnToThreadLoop=true;
 table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]}^${pops[1]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]}|${pops[1]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}.or(${pops[1]}),${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IAND] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]}&${pops[1]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LAND] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}.and(${pops[1]}),${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IADD] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=(${pops[0]}+${pops[1]})|0;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}.add(${pops[3]}),${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}+${pops[3]},${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=Math.imul(${pops[0]}, ${pops[1]});
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=util.wrapFloat(${pops[0]}*${pops[1]});
-frame.pc++;
+var ${pushes[0]}=u.wrapFloat(${pops[0]}*${pops[1]});
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}.multiply(${pops[1]}),${pushes[1]}= null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}*${pops[1]},${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
@@ -975,10 +975,10 @@ table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes,
   return `
 if(${pops[0]}===0){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArithmeticException;','/ by zero');
+u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
 }else{
-var ${pushes[0]}=(${pops[1]}===util.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);
-frame.pc++;
+var ${pushes[0]}=(${pops[1]}===u.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);
+f.pc++;
 ${onSuccess}
 }`;
 }};
@@ -986,28 +986,28 @@ ${onSuccess}
 table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}/${pops[1]},${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ISUB] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=(${pops[1]}-${pops[0]})|0;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}.negate().add(${pops[3]}),${pushes[1]}= null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}-${pops[1]},${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
@@ -1016,10 +1016,10 @@ table[OpCode.IREM] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes,
   return `
 if(${pops[0]}===0){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArithmeticException;','/ by zero');
+u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
 }else{
 var ${pushes[0]}=${pops[1]}%${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }`;
 }};
@@ -1029,10 +1029,10 @@ table[OpCode.LREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes,
   return `
 if(${pops[1]}.isZero()){
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/ArithmeticException;','/ by zero');
+u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
 }else{
 var ${pushes[0]}=${pops[3]}.modulo(${pops[1]}),${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}
 }`;
 }};
@@ -1040,140 +1040,140 @@ ${onSuccess}
 table[OpCode.DREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[3]}%${pops[1]},${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.INEG] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=(-${pops[0]})|0;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}.negate(),${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ISHL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}<<${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LSHL] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=${pops[2]}.shiftLeft(util.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=${pops[2]}.shiftLeft(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ISHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}>>${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=${pops[2]}.shiftRight(util.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=${pops[2]}.shiftRight(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IUSHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=(${pops[1]}>>>${pops[0]})|0;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LUSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(util.gLong.fromInt(${pops[0]}));
+var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(u.gLong.fromInt(${pops[0]}));
 var ${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2B] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=(${pops[0]}<<24)>>24;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2S] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=(${pops[0]}<<16)>>16;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2C] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]}&0xFFFF;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2L] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=util.gLong.fromInt(${pops[0]}),${pushes[1]}=null;
-frame.pc++;
+var ${pushes[0]}=u.gLong.fromInt(${pops[0]}),${pushes[1]}=null;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2F] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.F2I] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=util.float2int(${pops[0]});
-frame.pc++;
+var ${pushes[0]}=u.float2int(${pops[0]});
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.F2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.L2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}.toInt();
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.L2D] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]}.toNumber(),${pushes[1]}=null;
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.D2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=util.float2int(${pops[1]});
-frame.pc++;
+var ${pushes[0]}=u.float2int(${pops[1]});
+f.pc++;
 ${onSuccess}`;
 }};
 
@@ -1181,37 +1181,37 @@ ${onSuccess}`;
 table[OpCode.DUP] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP2] = {hasBranch: false, pops: 2, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[1]},${pushes[2]}=${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[2]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var classRef${suffix}=frame.method.cls.constantPool.get(${index}),
-${pushes[0]}=(new classRef${suffix}.clsConstructor(thread));
-frame.pc+=3;
+var classRef${suffix}=f.method.cls.constantPool.get(${index}),
+${pushes[0]}=(new classRef${suffix}.clsConstructor(t));
+f.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -1220,14 +1220,14 @@ table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pus
   const arrayType = "[" + opcodes.ArrayTypes[index];
   const onError = makeOnError(onErrorPushes);
   return `
-var cls${suffix}=frame.getLoader().getInitializedClass(thread,'${arrayType}');
+var cls${suffix}=f.getLoader().getInitializedClass(t,'${arrayType}');
 if(${pops[0]}>=0){
-var ${pushes[0]}=new (cls${suffix}.getConstructor(thread))(thread,${pops[0]});
-frame.pc+=2;
+var ${pushes[0]}=new (cls${suffix}.getConstructor(t))(t,${pops[0]});
+f.pc+=2;
 ${onSuccess}
 }else{
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/NegativeArraySizeException;','Tried to init ${arrayType} array with length '+${pops[0]});
+u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init ${arrayType} array with length '+${pops[0]});
 }`;
 }};
 
@@ -1236,32 +1236,32 @@ table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pop
   const arrayType = "[" + opcodes.ArrayTypes[index];
   const onError = makeOnError(onErrorPushes);
   return `
-var classRef${suffix}=frame.method.cls.constantPool.get(${index});
+var classRef${suffix}=f.method.cls.constantPool.get(${index});
 if(${pops[0]}>=0){
-var ${pushes[0]}=new classRef${suffix}.arrayClassConstructor(thread,${pops[0]});
-frame.pc+=3;
+var ${pushes[0]}=new classRef${suffix}.arrayClassConstructor(t,${pops[0]});
+f.pc+=3;
 ${onSuccess}
 }else{
 ${onError}
-util.throwException(thread,frame,'Ljava/lang/NegativeArraySizeException;','Tried to init '+classRef${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});
+u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init '+classRef${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});
 }`;
 }};
 
 table[OpCode.NOP] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.POP] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.POP2] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.pc++;
+f.pc++;
 ${onSuccess}`;
 }};
 

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -968,7 +968,7 @@ ${onSuccess}`;
 table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 if (${pops[0]} === 0) {
-  throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
+  util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
 } else {
   var ${pushes[0]} = (${pops[1]} === util.Constants.INT_MIN && ${pops[0]} === -1) ? ${pops[1]} : ((${pops[1]} / ${pops[0]}) | 0);
   frame.pc++;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -11,12 +11,7 @@ export interface JitInfo {
 }
 
 function makeOnError(onErrorPushes: string[]) {
-  let onError = "";
-  for (let j = 0; j < onErrorPushes.length; j++) {
-    const e = onErrorPushes[j];
-    onError += `frame.opStack.push(${e});`;
-  }
-  return onError;
+  return onErrorPushes.length > 0 ? `frame.opStack.pushAll(${onErrorPushes.join(',')})` : '';
 }
 
 export const opJitInfo: JitInfo[] = function() {

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -370,6 +370,16 @@ table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,${pushes[0]}=${pops[0]}!==null?(${pops[0]}.getClass().isCastable(cls${suffix})?1:0):0;f.pc+=3;${onSuccess}`;
 }};
 
+table[OpCode.CHECKCAST_FAST] = {hasBranch: false, pops: -1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  const index = code.readUInt16BE(pc + 1);
+  const classRef = <ConstantPool.ClassReference> method.cls.constantPool.get(index),
+    targetClass = classRef.cls.getExternalName();
+  return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,o${suffix}=${pops.length===1?pops[0]:'f.opStack.pop()'};
+if((o${suffix}!=null)&&!o${suffix}.getClass().isCastable(cls${suffix})){
+u.throwException(t,f,'Ljava/lang/ClassCastException;',o${suffix}.getClass().getExternalName()+' cannot be cast to ${targetClass}');
+}else{f.pc+=3;var ${pushes[0]}=o${suffix};${onSuccess}}`
+}};
+
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}}else{${onError}}`;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -714,7 +714,7 @@ ${onSuccess}`;
 table[OpCode.IFNONNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} !== null) {
+if(${pops[0]} != null) {
   frame.pc += ${offset};
 } else {
   frame.pc += 3;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -428,80 +428,94 @@ table[OpCode.GOTO] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, 
   return `f.pc+=${offset};${onSuccess}`;
 }};
 
-const cmpeq: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+const cmpeq: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}===${pops[1]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}===${pops[1]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
 table[OpCode.IF_ICMPEQ] = cmpeq;
 table[OpCode.IF_ACMPEQ] = cmpeq;
 
-const cmpne: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+const cmpne: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}!==${pops[1]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}!==${pops[1]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
 table[OpCode.IF_ICMPNE] = cmpne;
 table[OpCode.IF_ACMPNE] = cmpne;
 
-table[OpCode.IF_ICMPGE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IF_ICMPGE] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[1]}>=${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}>=${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IF_ICMPGT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IF_ICMPGT] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[1]}>${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}>${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IF_ICMPLE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IF_ICMPLE] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[1]}<=${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}<=${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IF_ICMPLT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IF_ICMPLT] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[1]}<${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}<${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFNULL] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}==null){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}==null){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFNONNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFNONNULL] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}!=null){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}!=null){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFEQ] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFEQ] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}===0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}===0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFNE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFNE] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}!==0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}!==0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFGT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFGT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}>0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}>0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFLT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFLT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}<0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}<0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFGE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFGE] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}>=0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}>=0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
-table[OpCode.IFLE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+table[OpCode.IFLE] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const offset = code.readInt16BE(pc + 1);
-  return `if(${pops[0]}<=0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}<=0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
 }};
 
 table[OpCode.LCMP] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -11,7 +11,7 @@ export interface JitInfo {
 }
 
 function makeOnError(onErrorPushes: string[]) {
-  return onErrorPushes.length > 0 ? `f.opStack.pushAll(${onErrorPushes.join(',')})` : '';
+  return onErrorPushes.length > 0 ? `f.opStack.pushAll(${onErrorPushes.join(',')});` : '';
 }
 
 export const opJitInfo: JitInfo[] = function() {
@@ -33,45 +33,27 @@ const table:JitInfo[] = [];
 const OpCode = enums.OpCode;
 
 table[OpCode.ACONST_NULL] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.ICONST_M1] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=-1;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=-1;f.pc++;${onSuccess}`;
 }};
 
 const load0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[0];
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[0];f.pc++;${onSuccess}`;
 }};
 
 const load1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[1];
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[1];f.pc++;${onSuccess}`;
 }};
 
 const load2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[2];
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[2];f.pc++;${onSuccess}`;
 }};
 
 const load3_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[3];
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[3];f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.ALOAD_0] = load0_32;
@@ -91,31 +73,19 @@ table[OpCode.ILOAD_3] = load3_32;
 table[OpCode.FLOAD_3] = load3_32;
 
 const load0_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[0],${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[0],${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 const load1_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[1],${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[1],${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 const load2_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[2],${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[2],${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 const load3_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=f.locals[3],${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[3],${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LLOAD_0] = load0_64;
@@ -131,31 +101,19 @@ table[OpCode.LLOAD_3] = load3_64;
 table[OpCode.DLOAD_3] = load3_64;
 
 const store0_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[0]=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[0]=${pops[0]};f.pc++;${onSuccess}`;
 }}
 
 const store1_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[1]=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[1]=${pops[0]};f.pc++;${onSuccess}`;
 }}
 
 const store2_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[2]=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[2]=${pops[0]};f.pc++;${onSuccess}`;
 }}
 
 const store3_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[3]=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[3]=${pops[0]};f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.ASTORE_0] = store0_32;
@@ -176,43 +134,23 @@ table[OpCode.FSTORE_3] = store3_32;
 
 const store_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readUInt8(pc + 1);
-  return `
-f.locals[${offset+1}]=${pops[0]};
-f.locals[${offset}]=${pops[1]};
-f.pc+=2;
-${onSuccess}`;
+  return `f.locals[${offset+1}]=${pops[0]};f.locals[${offset}]=${pops[1]};f.pc+=2;${onSuccess}`;
 }}
 
 const store0_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[1]=${pops[0]};
-f.locals[0]=${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[1]=${pops[0]};f.locals[0]=${pops[1]};f.pc++;${onSuccess}`;
 }}
 
 const store1_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[2]=${pops[0]};
-f.locals[1]=${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[2]=${pops[0]};f.locals[1]=${pops[1]};f.pc++;${onSuccess}`;
 }}
 
 const store2_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[3]=${pops[0]};
-f.locals[2]=${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[3]=${pops[0]};f.locals[2]=${pops[1]};f.pc++;${onSuccess}`;
 }}
 
 const store3_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.locals[4]=${pops[0]};
-f.locals[3]=${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `f.locals[4]=${pops[0]};f.locals[3]=${pops[1]};f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.LSTORE] = store_64;
@@ -231,22 +169,13 @@ table[OpCode.LSTORE_3] = store3_64;
 table[OpCode.DSTORE_3] = store3_64;
 
 const const0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=0;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=0;f.pc++;${onSuccess}`;
 }}
 const const1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=1;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=1;f.pc++;${onSuccess}`;
 }}
 const const2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=2;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=2;f.pc++;${onSuccess}`;
 }}
 
 
@@ -259,72 +188,44 @@ table[OpCode.FCONST_1] = const1_32;
 table[OpCode.FCONST_2] = const2_32;
 
 table[OpCode.ICONST_3] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=3;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=3;f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.ICONST_4] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=4;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=4;f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.ICONST_5] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=5;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=5;f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.LCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=u.gLong.ZERO,${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=u.gLong.ZERO,${pushes[1]}=null;f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.LCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=u.gLong.ONE,${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=u.gLong.ONE,${pushes[1]}=null;f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.DCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=0,${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=0,${pushes[1]}=null;f.pc++;${onSuccess}`;
 }}
 
 table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=1,${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=1,${pushes[1]}=null;f.pc++;${onSuccess}`;
 }}
 
 const aload32: JitInfo = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var idx${suffix}=${pops[0]},
-obj${suffix}=${pops[1]};
+var idx${suffix}=${pops[0]},obj${suffix}=${pops[1]};
 if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
 u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{
-var ${pushes[0]}=obj${suffix}.array[idx${suffix}];
-f.pc++;
-${onSuccess}
-}
-}else{
-${onError}
-}`;
+}else{var ${pushes[0]}=obj${suffix}.array[idx${suffix}];f.pc++;${onSuccess}}
+}else{${onError}}`;
 }}
 
 
@@ -338,21 +239,14 @@ table[OpCode.SALOAD] = aload32;
 const aload64: JitInfo = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var idx${suffix}=${pops[0]},
-obj${suffix}=${pops[1]};
+var idx${suffix}=${pops[0]},obj${suffix}=${pops[1]};
 if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
 u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{
-var ${pushes[0]}=obj${suffix}.array[idx${suffix}],${pushes[1]}=null;
-f.pc++;
-${onSuccess}
-}
-}else{
-${onError}
-}`;
+}else{var ${pushes[0]}=obj${suffix}.array[idx${suffix}],${pushes[1]}=null;f.pc++;${onSuccess}}
+}else{${onError}}`;
 }}
 
 
@@ -370,14 +264,8 @@ var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
 u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{
-obj${suffix}.array[idx${suffix}]=val${suffix};
-f.pc++;
-${onSuccess}
-}
-}else{
-${onError}
-}`;
+}else{obj${suffix}.array[idx${suffix}]=val${suffix};f.pc++;${onSuccess}}
+}else{${onError}}`;
 }}
 
 
@@ -399,14 +287,8 @@ var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){
 ${onError}
 u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{
-obj${suffix}.array[idx${suffix}]=val${suffix};
-f.pc++;
-${onSuccess}
-}
-}else{
-${onError}
-}`;
+}else{obj${suffix}.array[idx${suffix}]=val${suffix};f.pc++;${onSuccess}}
+}else{${onError}}`;
 }}
 
 
@@ -419,14 +301,8 @@ table[OpCode.LDC] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, 
   const onError = makeOnError(onErrorPushes);
   return `
 var constant${suffix}=f.method.cls.constantPool.get(${index});
-if(constant${suffix}.isResolved()){
-var ${pushes[0]}=constant${suffix}.getConstant(t);
-f.pc+=2;
-${onSuccess}
-}else{
-${onError}
-u.resolveCPItem(t,f,constant${suffix});
-}`;
+if(constant${suffix}.isResolved()){var ${pushes[0]}=constant${suffix}.getConstant(t);f.pc+=2;${onSuccess}
+}else{${onError}u.resolveCPItem(t,f,constant${suffix});}`;
 }};
 
 // TODO: get the constant at JIT time ?
@@ -435,24 +311,14 @@ table[OpCode.LDC_W] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes
   const onError = makeOnError(onErrorPushes);
   return `
 var constant${suffix}=f.method.cls.constantPool.get(${index});
-if(constant${suffix}.isResolved()){
-var ${pushes[0]}=constant${suffix}.getConstant(t);
-f.pc+=3;
-${onSuccess}
-}else{
-${onError}
-u.resolveCPItem(t,f,constant${suffix});
-}`;
+if(constant${suffix}.isResolved()){var ${pushes[0]}=constant${suffix}.getConstant(t);f.pc+=3;${onSuccess}
+}else{${onError}u.resolveCPItem(t,f,constant${suffix});}`;
 }};
 
 // TODO: get the constant at JIT time ?
 table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
-  return `
-var constant${suffix}=f.method.cls.constantPool.get(${index});
-var ${pushes[0]}=constant${suffix}.value,${pushes[1]}=null;
-f.pc+=3;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.method.cls.constantPool.get(${index}).value,${pushes[1]}=null;f.pc+=3;${onSuccess}`;
 }};
 
 // TODO: get the field info at JIT time ?
@@ -481,15 +347,9 @@ table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
-obj${suffix}=${pops[0]};
-if(!u.isNull(t,f,obj${suffix})){
-var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName];
-f.pc+=3;
-${onSuccess}
-}else{
-${onError}
-}`;
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[0]};
+if(!u.isNull(t,f,obj${suffix})){var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName];f.pc+=3;${onSuccess}
+}else{${onError}}`;
 }};
 
 // TODO: get the field info at JIT time ?
@@ -497,15 +357,9 @@ table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
-obj${suffix}=${pops[0]};
-if(!u.isNull(t,f,obj${suffix})){
-var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName],${pushes[1]}=null;
-f.pc+=3;
-${onSuccess}
-}else{
-${onError}
-}`;
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[0]};
+if(!u.isNull(t,f,obj${suffix})){var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName],${pushes[1]}=null;f.pc+=3;${onSuccess}
+}else{${onError}}`;
 }};
 
 // TODO: get the field info at JIT time ?
@@ -513,15 +367,9 @@ table[OpCode.PUTFIELD_FAST32] = {hasBranch: false, pops: 2, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
-obj${suffix}=${pops[1]};
-if(!u.isNull(t,f,obj${suffix})){
-obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[0]};
-f.pc+=3;
-${onSuccess}
-}else{
-${onError}
-}`;
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[1]};
+if(!u.isNull(t,f,obj${suffix})){obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[0]};f.pc+=3;${onSuccess}
+}else{${onError}}`;
 }};
 
 // TODO: get the field info at JIT time ?
@@ -529,47 +377,30 @@ table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
-obj${suffix}=${pops[2]};
-if(!u.isNull(t,f,obj${suffix})){
-obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[1]};
-f.pc+=3;
-${onSuccess}
-}else{
-${onError}
-}`;
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[2]};
+if(!u.isNull(t,f,obj${suffix})){obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[1]};f.pc+=3;${onSuccess}
+}else{${onError}}`;
 }};
 
 // TODO: get the constant at JIT time ?
 table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,
-o${suffix}=${pops[0]},
-${pushes[0]}=o${suffix}!==null?(o${suffix}.getClass().isCastable(cls${suffix})?1:0):0;
-f.pc+=3;
-${onSuccess}`;
+var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,o${suffix}=${pops[0]},${pushes[0]}=o${suffix}!==null?(o${suffix}.getClass().isCastable(cls${suffix})?1:0):0;
+f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
 var obj${suffix}=${pops[0]};
-if(!u.isNull(t,f,obj${suffix})){
-var ${pushes[0]}=obj${suffix}.array.length;
-f.pc++;
-${onSuccess}
-}else{
-${onError}
-}`;
+if(!u.isNull(t,f,obj${suffix})){var ${pushes[0]}=obj${suffix}.array.length;f.pc++;${onSuccess}
+}else{${onError}}`;
 }};
 
 const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
-  return `
-var ${pushes[0]}=f.locals[${index}];
-f.pc+=2;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[${index}];f.pc+=2;${onSuccess}`;
 }}
 
 table[OpCode.ILOAD] = load32;
@@ -578,10 +409,7 @@ table[OpCode.FLOAD] = load32;
 
 const load64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
-  return `
-var ${pushes[0]}=f.locals[${index}],${pushes[1]}=null;
-f.pc+=2;
-${onSuccess}`;
+  return `var ${pushes[0]}=f.locals[${index}],${pushes[1]}=null;f.pc+=2;${onSuccess}`;
 }}
 
 table[OpCode.LLOAD] = load64;
@@ -589,10 +417,7 @@ table[OpCode.DLOAD] = load64;
 
 const store32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
-  return `
-f.locals[${index}]=${pops[0]};
-f.pc+=2;
-${onSuccess}`;
+  return `f.locals[${index}]=${pops[0]};f.pc+=2;${onSuccess}`;
 }}
 
 table[OpCode.ISTORE] = store32;
@@ -601,54 +426,34 @@ table[OpCode.FSTORE] = store32;
 
 table[OpCode.BIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const value = code.readInt8(pc + 1);
-  return `
-var ${pushes[0]}=${value};
-f.pc+=2;
-${onSuccess}`;
+  return `var ${pushes[0]}=${value};f.pc+=2;${onSuccess}`;
 }};
 
 table[OpCode.SIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const value = code.readInt16BE(pc + 1);
-  return `
-var ${pushes[0]}=${value};
-f.pc+=3;
-${onSuccess}`;
+  return `var ${pushes[0]}=${value};f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.IINC] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const idx = code.readUInt8(pc + 1);
   const val = code.readInt8(pc + 2);
-  return `
-f.locals[${idx}]=(f.locals[${idx}]+${val})|0;
-f.pc+=3;
-${onSuccess}`;
+  return `f.locals[${idx}]=(f.locals[${idx}]+${val})|0;f.pc+=3;${onSuccess}`;
 }};
 
 // This is marked as hasBranch: true to stop further opcode inclusion during JITC. The name of "hasBranch" ought to be changed.
 table[OpCode.ATHROW] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
-  return `
-${onError}
-t.throwException(${pops[0]});
-f.returnToThreadLoop=true;`;
+  return `${onError}t.throwException(${pops[0]});f.returnToThreadLoop=true;`;
 }};
 
 table[OpCode.GOTO] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-f.pc+=${offset};
-${onSuccess}`;
+  return `f.pc+=${offset};${onSuccess}`;
 }};
 
 const cmpeq: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}===${pops[1]}){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}===${pops[1]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IF_ICMPEQ] = cmpeq;
@@ -656,13 +461,7 @@ table[OpCode.IF_ACMPEQ] = cmpeq;
 
 const cmpne: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}!==${pops[1]}){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}!==${pops[1]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IF_ICMPNE] = cmpne;
@@ -670,169 +469,82 @@ table[OpCode.IF_ACMPNE] = cmpne;
 
 table[OpCode.IF_ICMPGE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[1]}>=${pops[0]}){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[1]}>=${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IF_ICMPGT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[1]}>${pops[0]}){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[1]}>${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IF_ICMPLE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[1]}<=${pops[0]}){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[1]}<=${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IF_ICMPLT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[1]}<${pops[0]}){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[1]}<${pops[0]}){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}==null){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}==null){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFNONNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}!=null){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}!=null){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFEQ] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}===0){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}===0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFNE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}!==0){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}!==0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFGT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}>0){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}>0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFLT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}<0){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}<0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFGE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}>=0){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}>=0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.IFLE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
-  return `
-if(${pops[0]}<=0){
-f.pc+=${offset};
-}else{
-f.pc+=3;
-}
-${onSuccess}`;
+  return `if(${pops[0]}<=0){f.pc+=${offset};}else{f.pc+=3;}${onSuccess}`;
 }};
 
 table[OpCode.LCMP] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}.compare(${pops[1]});
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}.compare(${pops[1]});f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.FCMPL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}>${pops[0]}?1:-1);
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}>${pops[0]}?1:-1);f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DCMPL] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}>${pops[1]}?1:-1);
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}>${pops[1]}?1:-1);f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.FCMPG] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}<${pops[0]}?-1:1);
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}<${pops[0]}?-1:1);f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DCMPG] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}<${pops[1]}?-1:1);
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}<${pops[1]}?-1:1);f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix) => {
@@ -840,11 +552,7 @@ table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes
   // TODO: on error pushes
   return `
 f.returnToThreadLoop=true;
-if(f.method.accessFlags.isSynchronized()){
-if(!f.method.methodLock(t,f).exit(t)){
- return;
-}
-}
+if(f.method.accessFlags.isSynchronized()){if(!f.method.methodLock(t,f).exit(t)){ return;}}
 t.asyncReturn();
 `;
 }};
@@ -875,344 +583,193 @@ table[OpCode.DRETURN] = return64;
 
 table[OpCode.MONITOREXIT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
-  return `
-if(${pops[0]}.getMonitor().exit(t)){
-f.pc++;
-${onSuccess}
-}else{
-${onError}
-f.returnToThreadLoop=true;
-}
-`;
+  return `if(${pops[0]}.getMonitor().exit(t)){f.pc++;${onSuccess}}else{${onError}f.returnToThreadLoop=true;}`;
 }};
 
 table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]}^${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]}^${pops[1]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]}|${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]}|${pops[1]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}.or(${pops[1]}),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}.or(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IAND] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]}&${pops[1]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]}&${pops[1]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LAND] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}.and(${pops[1]}),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}.and(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IADD] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=(${pops[0]}+${pops[1]})|0;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=(${pops[0]}+${pops[1]})|0;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}.add(${pops[3]}),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}.add(${pops[3]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}+${pops[3]},${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}+${pops[3]},${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=Math.imul(${pops[0]}, ${pops[1]});
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=Math.imul(${pops[0]}, ${pops[1]});f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.FMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=u.wrapFloat(${pops[0]}*${pops[1]});
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=u.wrapFloat(${pops[0]}*${pops[1]});f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}.multiply(${pops[1]}),${pushes[1]}= null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}.multiply(${pops[1]}),${pushes[1]}= null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}*${pops[1]},${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}*${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-if(${pops[0]}===0){
-${onError}
-u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
-}else{
-var ${pushes[0]}=(${pops[1]}===u.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);
-f.pc++;
-${onSuccess}
-}`;
+if(${pops[0]}===0){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=(${pops[1]}===u.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);f.pc++;${onSuccess}}`;
 }};
 
 table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}/${pops[1]},${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}/${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.ISUB] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=(${pops[1]}-${pops[0]})|0;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=(${pops[1]}-${pops[0]})|0;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}.negate().add(${pops[3]}),${pushes[1]}= null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}.negate().add(${pops[3]}),${pushes[1]}= null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}-${pops[1]},${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}-${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IREM] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
-  return `
-if(${pops[0]}===0){
-${onError}
-u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
-}else{
-var ${pushes[0]}=${pops[1]}%${pops[0]};
-f.pc++;
-${onSuccess}
-}`;
+  return `if(${pops[0]}===0){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=${pops[1]}%${pops[0]};f.pc++;${onSuccess}}`;
 }};
 
 table[OpCode.LREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
-  return `
-if(${pops[1]}.isZero()){
-${onError}
-u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
-}else{
-var ${pushes[0]}=${pops[3]}.modulo(${pops[1]}),${pushes[1]}=null;
-f.pc++;
-${onSuccess}
-}`;
+  return `if(${pops[1]}.isZero()){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=${pops[3]}.modulo(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}}`;
 }};
 
 table[OpCode.DREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[3]}%${pops[1]},${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[3]}%${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.INEG] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=(-${pops[0]})|0;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=(-${pops[0]})|0;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}.negate(),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}.negate(),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.ISHL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}<<${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}<<${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LSHL] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[2]}.shiftLeft(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[2]}.shiftLeft(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.ISHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}>>${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}>>${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[2]}.shiftRight(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[2]}.shiftRight(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.IUSHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=(${pops[1]}>>>${pops[0]})|0;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=(${pops[1]}>>>${pops[0]})|0;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.LUSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(u.gLong.fromInt(${pops[0]}));
-var ${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2B] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=(${pops[0]}<<24)>>24;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=(${pops[0]}<<24)>>24;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2S] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=(${pops[0]}<<16)>>16;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=(${pops[0]}<<16)>>16;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2C] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]}&0xFFFF;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]}&0xFFFF;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2L] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=u.gLong.fromInt(${pops[0]}),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=u.gLong.fromInt(${pops[0]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2F] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.pc++;
-${onSuccess}`;
+  return `f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.I2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.F2I] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=u.float2int(${pops[0]});
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=u.float2int(${pops[0]});f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.F2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.L2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}.toInt();
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}.toInt();f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.L2D] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]}.toNumber(),${pushes[1]}=null;
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]}.toNumber(),${pushes[1]}=null;f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.D2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=u.float2int(${pops[1]});
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=u.float2int(${pops[1]});f.pc++;${onSuccess}`;
 }};
 
 // TODO: update the DUPs when peeking is supported
 table[OpCode.DUP] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DUP2] = {hasBranch: false, pops: 2, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[1]},${pushes[2]}=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[1]},${pushes[2]}=${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[2]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};
-f.pc++;
-${onSuccess}`;
+  return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[2]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
-  return `
-var classRef${suffix}=f.method.cls.constantPool.get(${index}),
-${pushes[0]}=(new classRef${suffix}.clsConstructor(t));
-f.pc+=3;
-${onSuccess}`;
+  return `var classRef${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=(new classRef${suffix}.clsConstructor(t));f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
@@ -1221,14 +778,8 @@ table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pus
   const onError = makeOnError(onErrorPushes);
   return `
 var cls${suffix}=f.getLoader().getInitializedClass(t,'${arrayType}');
-if(${pops[0]}>=0){
-var ${pushes[0]}=new (cls${suffix}.getConstructor(t))(t,${pops[0]});
-f.pc+=2;
-${onSuccess}
-}else{
-${onError}
-u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init ${arrayType} array with length '+${pops[0]});
-}`;
+if(${pops[0]}>=0){var ${pushes[0]}=new (cls${suffix}.getConstructor(t))(t,${pops[0]});f.pc+=2;${onSuccess}
+}else{${onError}u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init ${arrayType} array with length '+${pops[0]});}`;
 }};
 
 table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
@@ -1237,32 +788,20 @@ table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pop
   const onError = makeOnError(onErrorPushes);
   return `
 var classRef${suffix}=f.method.cls.constantPool.get(${index});
-if(${pops[0]}>=0){
-var ${pushes[0]}=new classRef${suffix}.arrayClassConstructor(t,${pops[0]});
-f.pc+=3;
-${onSuccess}
-}else{
-${onError}
-u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init '+classRef${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});
-}`;
+if(${pops[0]}>=0){var ${pushes[0]}=new classRef${suffix}.arrayClassConstructor(t,${pops[0]});f.pc+=3;${onSuccess}
+}else{${onError}u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init '+classRef${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});}`;
 }};
 
 table[OpCode.NOP] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.pc++;
-${onSuccess}`;
+  return `f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.POP] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.pc++;
-${onSuccess}`;
+  return `f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.POP2] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
-  return `
-f.pc++;
-${onSuccess}`;
+  return `f.pc++;${onSuccess}`;
 }};
 
 return table;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -1044,7 +1044,7 @@ ${onSuccess}`;
 
 table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[1]}.negate()) | 0;
+var ${pushes[0]} = ${pops[1]}.negate();
 var ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -812,35 +812,35 @@ if(${pops[0]} <= 0) {
 ${onSuccess}`;
 }};
 
-table[OpCode.LCMP] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+table[OpCode.LCMP] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]} = ${pops[3]}.compare(${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
-table[OpCode.FCMPL] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+table[OpCode.FCMPL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? 1 : -1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
-table[OpCode.DCMPL] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+table[OpCode.DCMPL] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? 1 : -1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
-table[OpCode.FCMPG] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+table[OpCode.FCMPG] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} < ${pops[0]} ? -1 : 1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
-table[OpCode.DCMPG] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+table[OpCode.DCMPG] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
 var ${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} < ${pops[1]} ? -1 : 1);
 frame.pc++;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -256,9 +256,7 @@ table[OpCode.LALOAD] = aload64;
 const astore32: JitInfo = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var val${suffix}=${pops[0]},
-idx${suffix}=${pops[1]},
-obj${suffix}=${pops[2]};
+var val${suffix}=${pops[0]},idx${suffix}=${pops[1]},obj${suffix}=${pops[2]};
 if(!u.isNull(t,f,obj${suffix})){
 var len${suffix}=obj${suffix}.array.length;
 if(idx${suffix}<0||idx${suffix}>=len${suffix}){

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -321,22 +321,15 @@ table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushe
 // TODO: get the field info at JIT time ?
 table[OpCode.GETSTATIC_FAST32] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
-  return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
-${pushes[0]}=fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
-f.pc+=3;
-${onSuccess}`;
+  return `var fi${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=fi${suffix}.fieldOwnerConstructor[fi${suffix}.fullFieldName];f.pc+=3;${onSuccess}`;
 }};
 
 // TODO: get the field info at JIT time ?
 table[OpCode.GETSTATIC_FAST64] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),
-${pushes[0]}=fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName],
-${pushes[1]}=null;
-f.pc+=3;
-${onSuccess}`;
+var fi${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=fi${suffix}.fieldOwnerConstructor[fi${suffix}.fullFieldName],
+${pushes[1]}=null;f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
@@ -374,16 +367,12 @@ table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (po
 // TODO: get the constant at JIT time ?
 table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
-  return `
-var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,${pushes[0]}=${pops[0]}!==null?(${pops[0]}.getClass().isCastable(cls${suffix})?1:0):0;
-f.pc+=3;${onSuccess}`;
+  return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,${pushes[0]}=${pops[0]}!==null?(${pops[0]}.getClass().isCastable(cls${suffix})?1:0):0;f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
-  return `
-if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}
-}else{${onError}}`;
+  return `if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}}else{${onError}}`;
 }};
 
 const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
@@ -754,7 +743,7 @@ table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushe
 
 table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
-  return `var classRef${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=(new classRef${suffix}.clsConstructor(t));f.pc+=3;${onSuccess}`;
+  return `var cr${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=(new cr${suffix}.clsConstructor(t));f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
@@ -772,9 +761,9 @@ table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pop
   const arrayType = "[" + opcodes.ArrayTypes[index];
   const onError = makeOnError(onErrorPushes);
   return `
-var classRef${suffix}=f.method.cls.constantPool.get(${index});
-if(${pops[0]}>=0){var ${pushes[0]}=new classRef${suffix}.arrayClassConstructor(t,${pops[0]});f.pc+=3;${onSuccess}
-}else{${onError}u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init '+classRef${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});}`;
+var cr${suffix}=f.method.cls.constantPool.get(${index});
+if(${pops[0]}>=0){var ${pushes[0]}=new cr${suffix}.arrayClassConstructor(t,${pops[0]});f.pc+=3;${onSuccess}
+}else{${onError}u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init '+cr${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});}`;
 }};
 
 table[OpCode.NOP] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -1,0 +1,1263 @@
+"use strict";
+
+import enums = require('./enums');
+import opcodes = require('./opcodes');
+
+export interface JitInfo {
+  pops: number,
+  pushes: number,
+  hasBranch: boolean,
+  emit: (pops: string[], pushes: string[], suffix: string, onSuccess: string, code: Buffer, pc: number, onErrorPushes: string[]) => string
+}
+
+function makeOnError(onErrorPushes: string[]) {
+  let onError = "";
+  for (let j = 0; j < onErrorPushes.length; j++) {
+    const e = onErrorPushes[j];
+    onError += `frame.opStack.push(${e});`;
+  }
+  return onError;
+}
+
+export const opJitInfo: JitInfo[] = function() {
+
+// Intentionally indented higher: emitted code is shorter.
+
+/*
+function indent(n: number, str: string): string {
+  return str;
+  let indentStr = "";
+  for (let i = 0; i < n; i++) {
+    indentStr += "  ";
+  }
+  return str.replace(/^(.)/gm, indentStr + "$1");
+}
+*/
+
+const table:JitInfo[] = [];
+const OpCode = enums.OpCode;
+
+table[OpCode.ACONST_NULL] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.ICONST_M1] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = -1;
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[0];
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[1];
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[2];
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load3_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[3];
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.ALOAD_0] = load0_32;
+table[OpCode.ILOAD_0] = load0_32;
+table[OpCode.FLOAD_0] = load0_32;
+
+table[OpCode.ALOAD_1] = load1_32;
+table[OpCode.ILOAD_1] = load1_32;
+table[OpCode.FLOAD_1] = load1_32;
+
+table[OpCode.ALOAD_2] = load2_32;
+table[OpCode.ILOAD_2] = load2_32;
+table[OpCode.FLOAD_2] = load2_32;
+
+table[OpCode.ALOAD_3] = load3_32;
+table[OpCode.ILOAD_3] = load3_32;
+table[OpCode.FLOAD_3] = load3_32;
+
+const load0_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[0];
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load1_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[1];
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load2_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[2];
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+const load3_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = frame.locals[3];
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LLOAD_0] = load0_64;
+table[OpCode.DLOAD_0] = load0_64;
+
+table[OpCode.LLOAD_1] = load1_64;
+table[OpCode.DLOAD_1] = load1_64;
+
+table[OpCode.LLOAD_2] = load2_64;
+table[OpCode.DLOAD_2] = load2_64;
+
+table[OpCode.LLOAD_3] = load3_64;
+table[OpCode.DLOAD_3] = load3_64;
+
+const store0_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[0] = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+const store1_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[1] = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+const store2_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[2] = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+const store3_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[3] = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.ASTORE_0] = store0_32;
+table[OpCode.ISTORE_0] = store0_32;
+table[OpCode.FSTORE_0] = store0_32;
+
+table[OpCode.ASTORE_1] = store1_32;
+table[OpCode.ISTORE_1] = store1_32;
+table[OpCode.FSTORE_1] = store1_32;
+
+table[OpCode.ASTORE_2] = store2_32;
+table[OpCode.ISTORE_2] = store2_32;
+table[OpCode.FSTORE_2] = store2_32;
+
+table[OpCode.ASTORE_3] = store3_32;
+table[OpCode.ISTORE_3] = store3_32;
+table[OpCode.FSTORE_3] = store3_32;
+
+const store_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readUInt8(pc + 1);
+  return `
+frame.locals[${offset + 1}] = ${pops[0]};
+frame.locals[${offset}] = ${pops[1]};
+frame.pc += 2;
+${onSuccess}`;
+}}
+
+const store0_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[1] = ${pops[0]};
+frame.locals[0] = ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+const store1_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[2] = ${pops[0]};
+frame.locals[1] = ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+const store2_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[3] = ${pops[0]};
+frame.locals[2] = ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+const store3_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.locals[4] = ${pops[0]};
+frame.locals[3] = ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.LSTORE] = store_64;
+table[OpCode.DSTORE] = store_64;
+
+table[OpCode.LSTORE_0] = store0_64;
+table[OpCode.DSTORE_0] = store0_64;
+
+table[OpCode.LSTORE_1] = store1_64;
+table[OpCode.DSTORE_1] = store1_64;
+
+table[OpCode.LSTORE_2] = store2_64;
+table[OpCode.DSTORE_2] = store2_64;
+
+table[OpCode.LSTORE_3] = store3_64;
+table[OpCode.DSTORE_3] = store3_64;
+
+const const0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 0;
+frame.pc++;
+${onSuccess}`;
+}}
+const const1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 1;
+frame.pc++;
+${onSuccess}`;
+}}
+const const2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 2;
+frame.pc++;
+${onSuccess}`;
+}}
+
+
+table[OpCode.ICONST_0] = const0_32;
+table[OpCode.ICONST_1] = const1_32;
+table[OpCode.ICONST_2] = const2_32;
+
+table[OpCode.FCONST_0] = const0_32;
+table[OpCode.FCONST_1] = const1_32;
+table[OpCode.FCONST_2] = const2_32;
+
+table[OpCode.ICONST_3] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 3;
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.ICONST_4] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 4;
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.ICONST_5] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 5;
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.LCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = util.gLong.ZERO;
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.LCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = util.gLong.ONE;
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.DCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 0;
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}}
+
+table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = 1;
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}}
+
+const aload32: JitInfo = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+var idx${suffix} = ${pops[0]},
+  obj${suffix} = ${pops[1]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var len${suffix} = obj${suffix}.array.length;
+  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
+    ${onError}
+    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
+  } else {
+    var ${pushes[0]} = obj${suffix}.array[idx${suffix}];
+    frame.pc++;
+    ${onSuccess}
+  }
+}`;
+}}
+
+
+table[OpCode.IALOAD] = aload32;
+table[OpCode.FALOAD] = aload32;
+table[OpCode.AALOAD] = aload32;
+table[OpCode.BALOAD] = aload32;
+table[OpCode.CALOAD] = aload32;
+table[OpCode.SALOAD] = aload32;
+
+const aload64: JitInfo = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+var idx${suffix} = ${pops[0]},
+  obj${suffix} = ${pops[1]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var len${suffix} = obj${suffix}.array.length;
+  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
+    ${onError}
+    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
+  } else {
+    var ${pushes[0]} = obj${suffix}.array[idx${suffix}];
+    var ${pushes[1]} = null;
+    frame.pc++;
+    ${onSuccess}
+  }
+}`;
+}}
+
+
+table[OpCode.DALOAD] = aload64;
+table[OpCode.LALOAD] = aload64;
+
+const astore32: JitInfo = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+var val${suffix} = ${pops[0]},
+  idx${suffix} = ${pops[1]},
+  obj${suffix} = ${pops[2]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var len${suffix} = obj${suffix}.array.length;
+  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
+    ${onError}
+    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
+  } else {
+    obj${suffix}.array[idx${suffix}] = val${suffix};
+    frame.pc++;
+    ${onSuccess}
+  }
+}`;
+}}
+
+
+table[OpCode.IASTORE] = astore32;
+table[OpCode.FASTORE] = astore32;
+table[OpCode.AASTORE] = astore32;
+table[OpCode.BASTORE] = astore32;
+table[OpCode.CASTORE] = astore32;
+table[OpCode.SASTORE] = astore32;
+
+const astore64: JitInfo = {hasBranch: false, pops: 4, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+var val${suffix} = ${pops[1]},
+  idx${suffix} = ${pops[2]},
+  obj${suffix} = ${pops[3]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var len${suffix} = obj${suffix}.array.length;
+  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
+    ${onError}
+    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
+  } else {
+    obj${suffix}.array[idx${suffix}] = val${suffix};
+    frame.pc++;
+    ${onSuccess}
+  }
+}`;
+}}
+
+
+table[OpCode.DASTORE] = astore64;
+table[OpCode.LASTORE] = astore64;
+
+// TODO: get the constant at JIT time ?
+table[OpCode.LDC] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const index = code.readUInt8(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `
+var constant${suffix} = frame.method.cls.constantPool.get(${index});
+if (constant${suffix}.isResolved()) {
+  var ${pushes[0]} = constant${suffix}.getConstant(thread);
+  frame.pc += 2;
+  ${onSuccess}
+} else {
+  ${onError}
+  util.resolveCPItem(thread, frame, constant${suffix});
+}`;
+}};
+
+// TODO: get the constant at JIT time ?
+table[OpCode.LDC_W] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const index = code.readUInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `
+var constant${suffix} = frame.method.cls.constantPool.get(${index});
+if (constant${suffix}.isResolved()) {
+  var ${pushes[0]} = constant${suffix}.getConstant(thread);
+  frame.pc += 3;
+  ${onSuccess}
+} else {
+  ${onError}
+  util.resolveCPItem(thread, frame, constant${suffix});
+}`;
+}};
+
+// TODO: get the constant at JIT time ?
+table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var constant${suffix} = frame.method.cls.constantPool.get(${index});
+var ${pushes[0]} = constant${suffix}.value;
+var ${pushes[1]} = null;
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.GETSTATIC_FAST32] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index});
+var ${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.GETSTATIC_FAST64] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index});
+var ${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
+var ${pushes[1]} = null;
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
+    obj${suffix} = ${pops[0]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var ${pushes[0]} = obj${suffix}[fieldInfo${suffix}.fullFieldName];
+  frame.pc += 3;
+  ${onSuccess}
+}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
+    obj${suffix} = ${pops[0]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var ${pushes[0]} = obj${suffix}[fieldInfo${suffix}.fullFieldName];
+  var ${pushes[1]} = null;
+  frame.pc += 3;
+  ${onSuccess}
+}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.PUTFIELD_FAST32] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
+    obj${suffix} = ${pops[1]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  obj${suffix}[fieldInfo${suffix}.fullFieldName] = ${pops[0]};
+  frame.pc += 3;
+  ${onSuccess}
+}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
+    obj${suffix} = ${pops[2]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  obj${suffix}[fieldInfo${suffix}.fullFieldName] = ${pops[1]};
+  frame.pc += 3;
+  ${onSuccess}
+}`;
+}};
+
+// TODO: get the constant at JIT time ?
+table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var cls${suffix} = frame.method.cls.constantPool.get(${index}).cls,
+  o${suffix} = ${pops[0]};
+var ${pushes[0]} = o${suffix} !== null ? (o${suffix}.getClass().isCastable(cls${suffix}) ? 1 : 0) : 0;
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var  obj${suffix} = ${pops[0]};
+if (!util.isNull(thread, frame, obj${suffix})) {
+  var ${pushes[0]} = obj${suffix}.array.length;
+  frame.pc++;
+  ${onSuccess}
+}`;
+}};
+
+const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  return `
+var ${pushes[0]} = frame.locals[${index}];
+frame.pc += 2;
+${onSuccess}`;
+}}
+
+table[OpCode.ILOAD] = load32;
+table[OpCode.ALOAD] = load32;
+table[OpCode.FLOAD] = load32;
+
+const load64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  return `
+var ${pushes[0]} = frame.locals[${index}];
+var ${pushes[1]} = null;
+frame.pc += 2;
+${onSuccess}`;
+}}
+
+table[OpCode.LLOAD] = load64;
+table[OpCode.DLOAD] = load64;
+
+const store32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  return `
+frame.locals[${index}] = ${pops[0]};
+frame.pc += 2;
+${onSuccess}`;
+}}
+
+table[OpCode.ISTORE] = store32;
+table[OpCode.ASTORE] = store32;
+table[OpCode.FSTORE] = store32;
+
+table[OpCode.BIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const value = code.readInt8(pc + 1);
+  return `
+var ${pushes[0]} = ${value};
+frame.pc += 2;
+${onSuccess}`;
+}};
+
+table[OpCode.SIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const value = code.readInt16BE(pc + 1);
+  return `
+var ${pushes[0]} = ${value};
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+table[OpCode.IINC] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const idx = code.readUInt8(pc + 1);
+  const val = code.readInt8(pc + 2);
+  return `
+frame.locals[${idx}] = (frame.locals[${idx}] + ${val}) | 0;
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+// This is marked as hasBranch: true to stop further opcode inclusion during JITC. The name of "hasBranch" ought to be changed.
+table[OpCode.ATHROW] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  return `
+thread.throwException(${pops[0]});
+frame.returnToThreadLoop = true;
+${onSuccess}`;
+}};
+
+table[OpCode.GOTO] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+frame.pc += ${offset};
+${onSuccess}`;
+}};
+
+const cmpeq: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} === ${pops[1]}) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IF_ICMPEQ] = cmpeq;
+table[OpCode.IF_ACMPEQ] = cmpeq;
+
+const cmpne: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} !== ${pops[1]}) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IF_ICMPNE] = cmpne;
+table[OpCode.IF_ACMPNE] = cmpne;
+
+table[OpCode.IF_ICMPGE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[1]} >= ${pops[0]}) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IF_ICMPGT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[1]} > ${pops[0]}) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IF_ICMPLE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[1]} <= ${pops[0]}) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IF_ICMPLT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[1]} < ${pops[0]}) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} === null) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFNONNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} !== null) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFEQ] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} === 0) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFNE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} !== 0) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFGT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} > 0) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFLT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} < 0) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFGE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} >= 0) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.IFLE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `
+if(${pops[0]} <= 0) {
+  frame.pc += ${offset};
+} else {
+  frame.pc += 3;
+}
+${onSuccess}`;
+}};
+
+table[OpCode.LCMP] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = ${pops[3]}.compare(${pops[1]});
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.FCMPL] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? -1 : 1);
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DCMPL] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? -1 : 1);
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.FCMPG] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} < ${pops[0]} ? -1 : 1);
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DCMPG] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} < ${pops[1]} ? -1 : 1);
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix) => {
+  // TODO: check flags at JIT time
+  // TODO: on error pushes
+  return `
+frame.returnToThreadLoop = true;
+if (frame.method.accessFlags.isSynchronized()) {
+  // monitorexit
+  if (!frame.method.methodLock(thread, frame).exit(thread)) {
+    // monitorexit threw an exception.
+    return;
+  }
+}
+thread.asyncReturn();
+`;
+}};
+
+const return32: JitInfo = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix) => {
+  // TODO: check flags at JIT time
+  // TODO: on error pushes
+  return `
+frame.returnToThreadLoop = true;
+if (frame.method.accessFlags.isSynchronized()) {
+  // monitorexit
+  if (!frame.method.methodLock(thread, frame).exit(thread)) {
+    // monitorexit threw an exception.
+    return;
+  }
+}
+thread.asyncReturn(${pops[0]});
+`;
+}};
+table[OpCode.IRETURN] = return32;
+table[OpCode.FRETURN] = return32;
+table[OpCode.ARETURN] = return32;
+
+const return64: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix) => {
+  // TODO: check flags at JIT time
+  return `
+frame.returnToThreadLoop = true;
+if (frame.method.accessFlags.isSynchronized()) {
+  // monitorexit
+  if (!frame.method.methodLock(thread, frame).exit(thread)) {
+    // monitorexit threw an exception.
+    return;
+  }
+}
+thread.asyncReturn(${pops[1]}, null);
+`;
+}};
+table[OpCode.LRETURN] = return64;
+table[OpCode.DRETURN] = return64;
+
+table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]} ^ ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]} | ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[3]}.or(${pops[1]});
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IAND] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]} & ${pops[1]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LAND] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[3]}.and(${pops[1]});
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IADD] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[0]} + ${pops[1]}) | 0;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]}.add(${pops[3]});
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]} + ${pops[3]};
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = Math.imul(${pops[0]},  ${pops[1]});
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.FMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = util.wrapFloat(${pops[0]} * ${pops[1]});
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[3]}.multiply(${pops[1]});
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[3]} * ${pops[1]};
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+if (${pops[0]} === 0) {
+  throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
+} else {
+  var ${pushes[0]} = (${pops[1]} === util.Constants.INT_MIN && ${pops[0]} === -1) ? ${pops[1]} : ((${pops[1]} / ${pops[0]}) | 0);
+  frame.pc++;
+  ${onSuccess}
+}`;
+}};
+
+table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[3]} / ${pops[1]};
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.ISUB] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[1]} - ${pops[0]}) | 0;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]}.negate().add(${pops[3]});
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[3]}-${pops[1]}) | 0;
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IREM] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+if (${pops[0]} === 0) {
+  util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
+} else {
+  var ${pushes[0]} = ${pops[1]} % ${pops[0]};
+  frame.pc++;
+  ${onSuccess}
+}`;
+}};
+
+table[OpCode.LREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+if (${pops[1]} === 0) {
+  util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
+} else {
+  var ${pushes[0]} = ${pops[3]}.modulo(${pops[1]});
+  var ${pushes[1]} = null;
+  frame.pc++;
+  ${onSuccess}
+}`;
+}};
+
+table[OpCode.INEG] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (-${pops[0]}) | 0;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[1]}.negate()) | 0;
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.ISHL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]} << ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LSHL] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[2]}.shiftLeft(util.gLong.fromInt(${pops[0]}));
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.ISHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]} >> ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[2]}.shiftRight(util.gLong.fromInt(${pops[0]}));
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.IUSHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[1]} >>> ${pops[0]}) | 0;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.LUSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[2]}.shiftRightUnsigned(util.gLong.fromInt(${pops[0]}));
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.I2B] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[0]} << 24) >> 24;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.I2S] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = (${pops[0]} << 16) >> 16;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.I2C] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]} & 0xFFFF;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.I2L] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = util.gLong.fromInt(${pops[0]});
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.I2F] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+// NOP; we represent ints as floats anyway.
+// @todo What about quantities unexpressable as floats?
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.I2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.F2I] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = util.float2int(${pops[0]});
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.F2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.L2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]}.toInt();
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.L2D] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]}.toNumber();
+var ${pushes[1]} = null;
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.D2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+${pushes[0]} = util.float2int(${pops[1]});
+frame.pc++;
+${onSuccess}`;
+}};
+
+// TODO: update the DUPs when peeking is supported
+table[OpCode.DUP] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]};
+var ${pushes[1]} = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DUP2] = {hasBranch: false, pops: 2, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[1]};
+var ${pushes[1]} = ${pops[0]};
+var ${pushes[2]} = ${pops[1]};
+var ${pushes[3]} = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+var ${pushes[0]} = ${pops[0]};
+var ${pushes[1]} = ${pops[1]};
+var ${pushes[2]} = ${pops[0]};
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var classRef${suffix} = frame.method.cls.constantPool.get(${index});
+var ${pushes[0]} = (new classRef${suffix}.clsConstructor(thread));
+frame.pc += 3;
+${onSuccess}`;
+}};
+
+table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  const arrayType = "[" + opcodes.ArrayTypes[index];
+  return `
+var cls${suffix} = frame.getLoader().getInitializedClass(thread, '${arrayType}');
+if (${pops[0]} >= 0) {
+  ${pushes[0]} = new (cls${suffix}.getConstructor(thread))(thread, ${pops[0]});
+  frame.pc += 2;
+  ${onSuccess}
+} else {
+  throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ${arrayType} array with length ' + ${pops[0]});
+}`;
+}};
+
+table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  const arrayType = "[" + opcodes.ArrayTypes[index];
+  return `
+var classRef${suffix} = frame.method.cls.constantPool.get(${index});
+if (${pops[0]} >= 0) {
+  ${pushes[0]} = new classRef${suffix}.arrayClassConstructor(thread, ${pops[0]});
+  frame.pc += 3;
+  ${onSuccess}
+} else {
+  throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ' + classRef${suffix}.arrayClass.getInternalName() + ' array with length ' + ${pops[0]});
+}`;
+}};
+
+table[OpCode.NOP] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.POP] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.pc++;
+${onSuccess}`;
+}};
+
+table[OpCode.POP2] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `
+frame.pc++;
+${onSuccess}`;
+}};
+
+return table;
+}();
+

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -1217,7 +1217,7 @@ if (${pops[0]} >= 0) {
   frame.pc += 2;
   ${onSuccess}
 } else {
-  throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ${arrayType} array with length ' + ${pops[0]});
+  util.throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ${arrayType} array with length ' + ${pops[0]});
 }`;
 }};
 
@@ -1231,7 +1231,7 @@ if (${pops[0]} >= 0) {
   frame.pc += 3;
   ${onSuccess}
 } else {
-  throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ' + classRef${suffix}.arrayClass.getInternalName() + ' array with length ' + ${pops[0]});
+  util.throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ' + classRef${suffix}.arrayClass.getInternalName() + ' array with length ' + ${pops[0]});
 }`;
 }};
 

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -218,13 +218,12 @@ table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pus
 const aload32: JitInfo = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var idx${suffix}=${pops[0]},obj${suffix}=${pops[1]};
-if(!u.isNull(t,f,obj${suffix})){
-var len${suffix}=obj${suffix}.array.length;
-if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+if(!u.isNull(t,f,${pops[1]})){
+var len${suffix}=${pops[1]}.array.length;
+if(${pops[0]}<0||${pops[0]}>=len${suffix}){
 ${onError}
-u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{var ${pushes[0]}=obj${suffix}.array[idx${suffix}];f.pc++;${onSuccess}}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[0]}+" not in length "+len${suffix}+" array of type "+${pops[1]}.getClass().getInternalName());
+}else{var ${pushes[0]}=${pops[1]}.array[${pops[0]}];f.pc++;${onSuccess}}
 }else{${onError}}`;
 }}
 
@@ -239,13 +238,12 @@ table[OpCode.SALOAD] = aload32;
 const aload64: JitInfo = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var idx${suffix}=${pops[0]},obj${suffix}=${pops[1]};
-if(!u.isNull(t,f,obj${suffix})){
-var len${suffix}=obj${suffix}.array.length;
-if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+if(!u.isNull(t,f,${pops[1]})){
+var len${suffix}=${pops[1]}.array.length;
+if(${pops[0]}<0||${pops[0]}>=len${suffix}){
 ${onError}
-u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{var ${pushes[0]}=obj${suffix}.array[idx${suffix}],${pushes[1]}=null;f.pc++;${onSuccess}}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[0]}+" not in length "+len${suffix}+" array of type "+${pops[1]}.getClass().getInternalName());
+}else{var ${pushes[0]}=${pops[1]}.array[${pops[0]}],${pushes[1]}=null;f.pc++;${onSuccess}}
 }else{${onError}}`;
 }}
 
@@ -256,13 +254,12 @@ table[OpCode.LALOAD] = aload64;
 const astore32: JitInfo = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var val${suffix}=${pops[0]},idx${suffix}=${pops[1]},obj${suffix}=${pops[2]};
-if(!u.isNull(t,f,obj${suffix})){
-var len${suffix}=obj${suffix}.array.length;
-if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+if(!u.isNull(t,f,${pops[2]})){
+var len${suffix}=${pops[2]}.array.length;
+if(${pops[1]}<0||${pops[1]}>=len${suffix}){
 ${onError}
-u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{obj${suffix}.array[idx${suffix}]=val${suffix};f.pc++;${onSuccess}}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[1]}+" not in length "+len${suffix}+" array of type "+${pops[2]}.getClass().getInternalName());
+}else{${pops[2]}.array[${pops[1]}]=${pops[0]};f.pc++;${onSuccess}}
 }else{${onError}}`;
 }}
 
@@ -277,15 +274,12 @@ table[OpCode.SASTORE] = astore32;
 const astore64: JitInfo = {hasBranch: false, pops: 4, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var val${suffix}=${pops[1]},
-idx${suffix}=${pops[2]},
-obj${suffix}=${pops[3]};
-if(!u.isNull(t,f,obj${suffix})){
-var len${suffix}=obj${suffix}.array.length;
-if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+if(!u.isNull(t,f,${pops[3]})){
+var len${suffix}=${pops[3]}.array.length;
+if(${pops[2]}<0||${pops[2]}>=len${suffix}){
 ${onError}
-u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
-}else{obj${suffix}.array[idx${suffix}]=val${suffix};f.pc++;${onSuccess}}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[2]}+" not in length "+len${suffix}+" array of type "+${pops[3]}.getClass().getInternalName());
+}else{${pops[3]}.array[${pops[2]}]=${pops[1]};f.pc++;${onSuccess}}
 }else{${onError}}`;
 }}
 
@@ -298,9 +292,9 @@ table[OpCode.LDC] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, 
   const index = code.readUInt8(pc + 1);
   const onError = makeOnError(onErrorPushes);
   return `
-var constant${suffix}=f.method.cls.constantPool.get(${index});
-if(constant${suffix}.isResolved()){var ${pushes[0]}=constant${suffix}.getConstant(t);f.pc+=2;${onSuccess}
-}else{${onError}u.resolveCPItem(t,f,constant${suffix});}`;
+var cnst${suffix}=f.method.cls.constantPool.get(${index});
+if(cnst${suffix}.isResolved()){var ${pushes[0]}=cnst${suffix}.getConstant(t);f.pc+=2;${onSuccess}
+}else{${onError}u.resolveCPItem(t,f,cnst${suffix});}`;
 }};
 
 // TODO: get the constant at JIT time ?
@@ -308,9 +302,9 @@ table[OpCode.LDC_W] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes
   const index = code.readUInt16BE(pc + 1);
   const onError = makeOnError(onErrorPushes);
   return `
-var constant${suffix}=f.method.cls.constantPool.get(${index});
-if(constant${suffix}.isResolved()){var ${pushes[0]}=constant${suffix}.getConstant(t);f.pc+=3;${onSuccess}
-}else{${onError}u.resolveCPItem(t,f,constant${suffix});}`;
+var cnst${suffix}=f.method.cls.constantPool.get(${index});
+if(cnst${suffix}.isResolved()){var ${pushes[0]}=cnst${suffix}.getConstant(t);f.pc+=3;${onSuccess}
+}else{${onError}u.resolveCPItem(t,f,cnst${suffix});}`;
 }};
 
 // TODO: get the constant at JIT time ?
@@ -345,8 +339,8 @@ table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[0]};
-if(!u.isNull(t,f,obj${suffix})){var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName];f.pc+=3;${onSuccess}
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index});
+if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}[fieldInfo${suffix}.fullFieldName];f.pc+=3;${onSuccess}
 }else{${onError}}`;
 }};
 
@@ -355,8 +349,8 @@ table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[0]};
-if(!u.isNull(t,f,obj${suffix})){var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName],${pushes[1]}=null;f.pc+=3;${onSuccess}
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index});
+if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}[fieldInfo${suffix}.fullFieldName],${pushes[1]}=null;f.pc+=3;${onSuccess}
 }else{${onError}}`;
 }};
 
@@ -365,8 +359,8 @@ table[OpCode.PUTFIELD_FAST32] = {hasBranch: false, pops: 2, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[1]};
-if(!u.isNull(t,f,obj${suffix})){obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[0]};f.pc+=3;${onSuccess}
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index});
+if(!u.isNull(t,f,${pops[1]})){${pops[1]}[fieldInfo${suffix}.fullFieldName]=${pops[0]};f.pc+=3;${onSuccess}
 }else{${onError}}`;
 }};
 
@@ -375,8 +369,8 @@ table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix}=f.method.cls.constantPool.get(${index}),obj${suffix}=${pops[2]};
-if(!u.isNull(t,f,obj${suffix})){obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[1]};f.pc+=3;${onSuccess}
+var fieldInfo${suffix}=f.method.cls.constantPool.get(${index});
+if(!u.isNull(t,f,${pops[2]})){${pops[2]}[fieldInfo${suffix}.fullFieldName]=${pops[1]};f.pc+=3;${onSuccess}
 }else{${onError}}`;
 }};
 
@@ -384,15 +378,14 @@ if(!u.isNull(t,f,obj${suffix})){obj${suffix}[fieldInfo${suffix}.fullFieldName]=$
 table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,o${suffix}=${pops[0]},${pushes[0]}=o${suffix}!==null?(o${suffix}.getClass().isCastable(cls${suffix})?1:0):0;
+var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,${pushes[0]}=${pops[0]}!==null?(${pops[0]}.getClass().isCastable(cls${suffix})?1:0):0;
 f.pc+=3;${onSuccess}`;
 }};
 
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var obj${suffix}=${pops[0]};
-if(!u.isNull(t,f,obj${suffix})){var ${pushes[0]}=obj${suffix}.array.length;f.pc++;${onSuccess}
+if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}
 }else{${onError}}`;
 }};
 

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -703,7 +703,7 @@ ${onSuccess}`;
 table[OpCode.IFNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} === null) {
+if(${pops[0]} == null) {
   frame.pc += ${offset};
 } else {
   frame.pc += 3;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -92,32 +92,28 @@ table[OpCode.FLOAD_3] = load3_32;
 
 const load0_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[0];
-var ${pushes[1]} = null;
+var ${pushes[0]} = frame.locals[0], ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load1_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[1];
-var ${pushes[1]} = null;
+var ${pushes[0]} = frame.locals[1], ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load2_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[2];
-var ${pushes[1]} = null;
+var ${pushes[0]} = frame.locals[2], ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load3_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[3];
-var ${pushes[1]} = null;
+var ${pushes[0]} = frame.locals[3], ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -285,32 +281,28 @@ ${onSuccess}`;
 
 table[OpCode.LCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.gLong.ZERO;
-var ${pushes[1]} = null;
+var ${pushes[0]} = util.gLong.ZERO, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.LCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.gLong.ONE;
-var ${pushes[1]} = null;
+var ${pushes[0]} = util.gLong.ONE, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.DCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 0;
-var ${pushes[1]} = null;
+var ${pushes[0]} = 0, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 1;
-var ${pushes[1]} = null;
+var ${pushes[0]} = 1, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }}
@@ -354,8 +346,7 @@ if (!util.isNull(thread, frame, obj${suffix})) {
     ${onError}
     util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
   } else {
-    var ${pushes[0]} = obj${suffix}.array[idx${suffix}];
-    var ${pushes[1]} = null;
+    var ${pushes[0]} = obj${suffix}.array[idx${suffix}], ${pushes[1]} = null;
     frame.pc++;
     ${onSuccess}
   }
@@ -459,8 +450,7 @@ table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushe
   const index = code.readUInt16BE(pc + 1);
   return `
 var constant${suffix} = frame.method.cls.constantPool.get(${index});
-var ${pushes[0]} = constant${suffix}.value;
-var ${pushes[1]} = null;
+var ${pushes[0]} = constant${suffix}.value, ${pushes[1]} = null;
 frame.pc += 3;
 ${onSuccess}`;
 }};
@@ -469,8 +459,8 @@ ${onSuccess}`;
 table[OpCode.GETSTATIC_FAST32] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index});
-var ${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
+${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
 frame.pc += 3;
 ${onSuccess}`;
 }};
@@ -479,9 +469,9 @@ ${onSuccess}`;
 table[OpCode.GETSTATIC_FAST64] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index});
-var ${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
-var ${pushes[1]} = null;
+var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
+${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName],
+${pushes[1]} = null;
 frame.pc += 3;
 ${onSuccess}`;
 }};
@@ -510,8 +500,7 @@ table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (po
 var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
     obj${suffix} = ${pops[0]};
 if (!util.isNull(thread, frame, obj${suffix})) {
-  var ${pushes[0]} = obj${suffix}[fieldInfo${suffix}.fullFieldName];
-  var ${pushes[1]} = null;
+  var ${pushes[0]} = obj${suffix}[fieldInfo${suffix}.fullFieldName], ${pushes[1]} = null;
   frame.pc += 3;
   ${onSuccess}
 } else {
@@ -556,8 +545,8 @@ table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   const index = code.readUInt16BE(pc + 1);
   return `
 var cls${suffix} = frame.method.cls.constantPool.get(${index}).cls,
-  o${suffix} = ${pops[0]};
-var ${pushes[0]} = o${suffix} !== null ? (o${suffix}.getClass().isCastable(cls${suffix}) ? 1 : 0) : 0;
+o${suffix} = ${pops[0]},
+${pushes[0]} = o${suffix} !== null ? (o${suffix}.getClass().isCastable(cls${suffix}) ? 1 : 0) : 0;
 frame.pc += 3;
 ${onSuccess}`;
 }};
@@ -590,8 +579,7 @@ table[OpCode.FLOAD] = load32;
 const load64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-var ${pushes[0]} = frame.locals[${index}];
-var ${pushes[1]} = null;
+var ${pushes[0]} = frame.locals[${index}], ${pushes[1]} = null;
 frame.pc += 2;
 ${onSuccess}`;
 }}
@@ -922,8 +910,7 @@ ${onSuccess}`;
 
 table[OpCode.LOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.or(${pops[1]});
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]}.or(${pops[1]}), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -937,8 +924,7 @@ ${onSuccess}`;
 
 table[OpCode.LAND] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.and(${pops[1]});
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]}.and(${pops[1]}), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -952,16 +938,14 @@ ${onSuccess}`;
 
 table[OpCode.LADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.add(${pops[3]});
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[1]}.add(${pops[3]}), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]} + ${pops[3]};
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[1]} + ${pops[3]}, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -982,16 +966,14 @@ ${onSuccess}`;
 
 table[OpCode.LMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.multiply(${pops[1]});
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]}.multiply(${pops[1]}), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} * ${pops[1]};
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]} * ${pops[1]}, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1011,8 +993,7 @@ if (${pops[0]} === 0) {
 
 table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} / ${pops[1]};
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]} / ${pops[1]}, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1026,16 +1007,14 @@ ${onSuccess}`;
 
 table[OpCode.LSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.negate().add(${pops[3]});
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[1]}.negate().add(${pops[3]}), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}-${pops[1]};
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]}-${pops[1]}, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1060,8 +1039,7 @@ if (${pops[1]}.isZero()) {
   ${onError}
   util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
 } else {
-  var ${pushes[0]} = ${pops[3]}.modulo(${pops[1]});
-  var ${pushes[1]} = null;
+  var ${pushes[0]} = ${pops[3]}.modulo(${pops[1]}), ${pushes[1]} = null;
   frame.pc++;
   ${onSuccess}
 }`;
@@ -1069,8 +1047,7 @@ if (${pops[1]}.isZero()) {
 
 table[OpCode.DREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} % ${pops[1]};
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[3]} % ${pops[1]}, ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1084,8 +1061,7 @@ ${onSuccess}`;
 
 table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.negate();
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[1]}.negate(), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1099,8 +1075,7 @@ ${onSuccess}`;
 
 table[OpCode.LSHL] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[2]}.shiftLeft(util.gLong.fromInt(${pops[0]}));
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[2]}.shiftLeft(util.gLong.fromInt(${pops[0]})), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1114,8 +1089,7 @@ ${onSuccess}`;
 
 table[OpCode.LSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[2]}.shiftRight(util.gLong.fromInt(${pops[0]}));
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[2]}.shiftRight(util.gLong.fromInt(${pops[0]})), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1158,8 +1132,7 @@ ${onSuccess}`;
 
 table[OpCode.I2L] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.gLong.fromInt(${pops[0]});
-var ${pushes[1]} = null;
+var ${pushes[0]} = util.gLong.fromInt(${pops[0]}), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1179,14 +1152,14 @@ ${onSuccess}`;
 
 table[OpCode.F2I] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = util.float2int(${pops[0]});
+var ${pushes[0]} = util.float2int(${pops[0]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.F2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = null;
+var ${pushes[0]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1200,15 +1173,14 @@ ${onSuccess}`;
 
 table[OpCode.L2D] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.toNumber();
-var ${pushes[1]} = null;
+var ${pushes[0]} = ${pops[1]}.toNumber(), ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.D2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = util.float2int(${pops[1]});
+var ${pushes[0]} = util.float2int(${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1216,37 +1188,28 @@ ${onSuccess}`;
 // TODO: update the DUPs when peeking is supported
 table[OpCode.DUP] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]};
-var ${pushes[1]} = ${pops[0]};
+var ${pushes[0]} = ${pops[0]}, ${pushes[1]} = ${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP2] = {hasBranch: false, pops: 2, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]};
-var ${pushes[1]} = ${pops[0]};
-var ${pushes[2]} = ${pops[1]};
-var ${pushes[3]} = ${pops[0]};
+var ${pushes[0]} = ${pops[1]}, ${pushes[1]} = ${pops[0]}, ${pushes[2]} = ${pops[1]}, ${pushes[3]} = ${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]};
-var ${pushes[1]} = ${pops[1]};
-var ${pushes[2]} = ${pops[0]};
+var ${pushes[0]} = ${pops[0]}, ${pushes[1]} = ${pops[1]}, ${pushes[2]} = ${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]};
-var ${pushes[1]} = ${pops[2]};
-var ${pushes[2]} = ${pops[1]};
-var ${pushes[3]} = ${pops[0]};
+var ${pushes[0]} = ${pops[0]}, ${pushes[1]} = ${pops[2]}, ${pushes[2]} = ${pops[1]}, ${pushes[3]} = ${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1254,8 +1217,8 @@ ${onSuccess}`;
 table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var classRef${suffix} = frame.method.cls.constantPool.get(${index});
-var ${pushes[0]} = (new classRef${suffix}.clsConstructor(thread));
+var classRef${suffix} = frame.method.cls.constantPool.get(${index}),
+${pushes[0]} = (new classRef${suffix}.clsConstructor(thread));
 frame.pc += 3;
 ${onSuccess}`;
 }};
@@ -1267,7 +1230,7 @@ table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pus
   return `
 var cls${suffix} = frame.getLoader().getInitializedClass(thread, '${arrayType}');
 if (${pops[0]} >= 0) {
-  ${pushes[0]} = new (cls${suffix}.getConstructor(thread))(thread, ${pops[0]});
+  var ${pushes[0]} = new (cls${suffix}.getConstructor(thread))(thread, ${pops[0]});
   frame.pc += 2;
   ${onSuccess}
 } else {
@@ -1283,7 +1246,7 @@ table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pop
   return `
 var classRef${suffix} = frame.method.cls.constantPool.get(${index});
 if (${pops[0]} >= 0) {
-  ${pushes[0]} = new classRef${suffix}.arrayClassConstructor(thread, ${pops[0]});
+  var ${pushes[0]} = new classRef${suffix}.arrayClassConstructor(thread, ${pops[0]});
   frame.pc += 3;
   ${onSuccess}
 } else {

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -809,7 +809,7 @@ ${onSuccess}`;
 
 table[OpCode.DCMPL] = {hasBranch: true, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? -1 : 1);
+${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? 1 : -1);
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1006,7 +1006,7 @@ ${onSuccess}`;
 
 table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[3]}-${pops[1]}) | 0;
+var ${pushes[0]} = ${pops[3]}-${pops[1]};
 var ${pushes[1]} = null;
 frame.pc++;
 ${onSuccess}`;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -797,7 +797,7 @@ ${onSuccess}`;
 
 table[OpCode.FCMPL] = {hasBranch: true, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? -1 : 1);
+var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? 1 : -1);
 frame.pc++;
 ${onSuccess}`;
 }};

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -1020,7 +1020,7 @@ if (${pops[0]} === 0) {
 
 table[OpCode.LREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-if (${pops[1]} === 0) {
+if (${pops[1]}.isZero()) {
   util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
 } else {
   var ${pushes[0]} = ${pops[3]}.modulo(${pops[1]});

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -34,42 +34,42 @@ const OpCode = enums.OpCode;
 
 table[OpCode.ACONST_NULL] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = null;
+var ${pushes[0]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ICONST_M1] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = -1;
+var ${pushes[0]}=-1;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[0];
+var ${pushes[0]}=frame.locals[0];
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[1];
+var ${pushes[0]}=frame.locals[1];
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[2];
+var ${pushes[0]}=frame.locals[2];
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load3_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[3];
+var ${pushes[0]}=frame.locals[3];
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -92,28 +92,28 @@ table[OpCode.FLOAD_3] = load3_32;
 
 const load0_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[0], ${pushes[1]} = null;
+var ${pushes[0]}=frame.locals[0],${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load1_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[1], ${pushes[1]} = null;
+var ${pushes[0]}=frame.locals[1],${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load2_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[2], ${pushes[1]} = null;
+var ${pushes[0]}=frame.locals[2],${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 const load3_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = frame.locals[3], ${pushes[1]} = null;
+var ${pushes[0]}=frame.locals[3],${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -132,28 +132,28 @@ table[OpCode.DLOAD_3] = load3_64;
 
 const store0_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[0] = ${pops[0]};
+frame.locals[0]=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }}
 
 const store1_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[1] = ${pops[0]};
+frame.locals[1]=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }}
 
 const store2_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[2] = ${pops[0]};
+frame.locals[2]=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }}
 
 const store3_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[3] = ${pops[0]};
+frame.locals[3]=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }}
@@ -177,40 +177,40 @@ table[OpCode.FSTORE_3] = store3_32;
 const store_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readUInt8(pc + 1);
   return `
-frame.locals[${offset + 1}] = ${pops[0]};
-frame.locals[${offset}] = ${pops[1]};
-frame.pc += 2;
+frame.locals[${offset+1}]=${pops[0]};
+frame.locals[${offset}]=${pops[1]};
+frame.pc+=2;
 ${onSuccess}`;
 }}
 
 const store0_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[1] = ${pops[0]};
-frame.locals[0] = ${pops[1]};
+frame.locals[1]=${pops[0]};
+frame.locals[0]=${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }}
 
 const store1_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[2] = ${pops[0]};
-frame.locals[1] = ${pops[1]};
+frame.locals[2]=${pops[0]};
+frame.locals[1]=${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }}
 
 const store2_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[3] = ${pops[0]};
-frame.locals[2] = ${pops[1]};
+frame.locals[3]=${pops[0]};
+frame.locals[2]=${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }}
 
 const store3_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-frame.locals[4] = ${pops[0]};
-frame.locals[3] = ${pops[1]};
+frame.locals[4]=${pops[0]};
+frame.locals[3]=${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }}
@@ -232,19 +232,19 @@ table[OpCode.DSTORE_3] = store3_64;
 
 const const0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 0;
+var ${pushes[0]}=0;
 frame.pc++;
 ${onSuccess}`;
 }}
 const const1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 1;
+var ${pushes[0]}=1;
 frame.pc++;
 ${onSuccess}`;
 }}
 const const2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 2;
+var ${pushes[0]}=2;
 frame.pc++;
 ${onSuccess}`;
 }}
@@ -260,49 +260,49 @@ table[OpCode.FCONST_2] = const2_32;
 
 table[OpCode.ICONST_3] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 3;
+var ${pushes[0]}=3;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.ICONST_4] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 4;
+var ${pushes[0]}=4;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.ICONST_5] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 5;
+var ${pushes[0]}=5;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.LCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.gLong.ZERO, ${pushes[1]} = null;
+var ${pushes[0]}=util.gLong.ZERO,${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.LCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.gLong.ONE, ${pushes[1]} = null;
+var ${pushes[0]}=util.gLong.ONE,${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.DCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 0, ${pushes[1]} = null;
+var ${pushes[0]}=0,${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }}
 
 table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = 1, ${pushes[1]} = null;
+var ${pushes[0]}=1,${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }}
@@ -310,20 +310,20 @@ ${onSuccess}`;
 const aload32: JitInfo = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var idx${suffix} = ${pops[0]},
-  obj${suffix} = ${pops[1]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var len${suffix} = obj${suffix}.array.length;
-  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
-    ${onError}
-    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
-  } else {
-    var ${pushes[0]} = obj${suffix}.array[idx${suffix}];
-    frame.pc++;
-    ${onSuccess}
-  }
-} else {
-  ${onError}
+var idx${suffix}=${pops[0]},
+obj${suffix}=${pops[1]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var len${suffix}=obj${suffix}.array.length;
+if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+}else{
+var ${pushes[0]}=obj${suffix}.array[idx${suffix}];
+frame.pc++;
+${onSuccess}
+}
+}else{
+${onError}
 }`;
 }}
 
@@ -338,20 +338,20 @@ table[OpCode.SALOAD] = aload32;
 const aload64: JitInfo = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var idx${suffix} = ${pops[0]},
-  obj${suffix} = ${pops[1]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var len${suffix} = obj${suffix}.array.length;
-  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
-    ${onError}
-    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
-  } else {
-    var ${pushes[0]} = obj${suffix}.array[idx${suffix}], ${pushes[1]} = null;
-    frame.pc++;
-    ${onSuccess}
-  }
-} else {
-  ${onError}
+var idx${suffix}=${pops[0]},
+obj${suffix}=${pops[1]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var len${suffix}=obj${suffix}.array.length;
+if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+}else{
+var ${pushes[0]}=obj${suffix}.array[idx${suffix}],${pushes[1]}=null;
+frame.pc++;
+${onSuccess}
+}
+}else{
+${onError}
 }`;
 }}
 
@@ -362,21 +362,21 @@ table[OpCode.LALOAD] = aload64;
 const astore32: JitInfo = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var val${suffix} = ${pops[0]},
-  idx${suffix} = ${pops[1]},
-  obj${suffix} = ${pops[2]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var len${suffix} = obj${suffix}.array.length;
-  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
-    ${onError}
-    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
-  } else {
-    obj${suffix}.array[idx${suffix}] = val${suffix};
-    frame.pc++;
-    ${onSuccess}
-  }
-} else {
-  ${onError}
+var val${suffix}=${pops[0]},
+idx${suffix}=${pops[1]},
+obj${suffix}=${pops[2]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var len${suffix}=obj${suffix}.array.length;
+if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+}else{
+obj${suffix}.array[idx${suffix}]=val${suffix};
+frame.pc++;
+${onSuccess}
+}
+}else{
+${onError}
 }`;
 }}
 
@@ -391,21 +391,21 @@ table[OpCode.SASTORE] = astore32;
 const astore64: JitInfo = {hasBranch: false, pops: 4, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var val${suffix} = ${pops[1]},
-  idx${suffix} = ${pops[2]},
-  obj${suffix} = ${pops[3]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var len${suffix} = obj${suffix}.array.length;
-  if (idx${suffix} < 0 || idx${suffix} >= len${suffix}) {
-    ${onError}
-    util.throwException(thread, frame, 'Ljava/lang/ArrayIndexOutOfBoundsException;', "" + idx${suffix} + " not in length " + len${suffix} + " array of type " + obj${suffix}.getClass().getInternalName());
-  } else {
-    obj${suffix}.array[idx${suffix}] = val${suffix};
-    frame.pc++;
-    ${onSuccess}
-  }
-} else {
-  ${onError}
+var val${suffix}=${pops[1]},
+idx${suffix}=${pops[2]},
+obj${suffix}=${pops[3]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var len${suffix}=obj${suffix}.array.length;
+if(idx${suffix}<0||idx${suffix}>=len${suffix}){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+idx${suffix}+" not in length "+len${suffix}+" array of type "+obj${suffix}.getClass().getInternalName());
+}else{
+obj${suffix}.array[idx${suffix}]=val${suffix};
+frame.pc++;
+${onSuccess}
+}
+}else{
+${onError}
 }`;
 }}
 
@@ -418,14 +418,14 @@ table[OpCode.LDC] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, 
   const index = code.readUInt8(pc + 1);
   const onError = makeOnError(onErrorPushes);
   return `
-var constant${suffix} = frame.method.cls.constantPool.get(${index});
-if (constant${suffix}.isResolved()) {
-  var ${pushes[0]} = constant${suffix}.getConstant(thread);
-  frame.pc += 2;
-  ${onSuccess}
-} else {
-  ${onError}
-  util.resolveCPItem(thread, frame, constant${suffix});
+var constant${suffix}=frame.method.cls.constantPool.get(${index});
+if(constant${suffix}.isResolved()){
+var ${pushes[0]}=constant${suffix}.getConstant(thread);
+frame.pc+=2;
+${onSuccess}
+}else{
+${onError}
+util.resolveCPItem(thread,frame,constant${suffix});
 }`;
 }};
 
@@ -434,14 +434,14 @@ table[OpCode.LDC_W] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes
   const index = code.readUInt16BE(pc + 1);
   const onError = makeOnError(onErrorPushes);
   return `
-var constant${suffix} = frame.method.cls.constantPool.get(${index});
-if (constant${suffix}.isResolved()) {
-  var ${pushes[0]} = constant${suffix}.getConstant(thread);
-  frame.pc += 3;
-  ${onSuccess}
-} else {
-  ${onError}
-  util.resolveCPItem(thread, frame, constant${suffix});
+var constant${suffix}=frame.method.cls.constantPool.get(${index});
+if(constant${suffix}.isResolved()){
+var ${pushes[0]}=constant${suffix}.getConstant(thread);
+frame.pc+=3;
+${onSuccess}
+}else{
+${onError}
+util.resolveCPItem(thread,frame,constant${suffix});
 }`;
 }};
 
@@ -449,9 +449,9 @@ if (constant${suffix}.isResolved()) {
 table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var constant${suffix} = frame.method.cls.constantPool.get(${index});
-var ${pushes[0]} = constant${suffix}.value, ${pushes[1]} = null;
-frame.pc += 3;
+var constant${suffix}=frame.method.cls.constantPool.get(${index});
+var ${pushes[0]}=constant${suffix}.value,${pushes[1]}=null;
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -459,9 +459,9 @@ ${onSuccess}`;
 table[OpCode.GETSTATIC_FAST32] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
-${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
-frame.pc += 3;
+var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+${pushes[0]}=fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName];
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -469,10 +469,10 @@ ${onSuccess}`;
 table[OpCode.GETSTATIC_FAST64] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
-${pushes[0]} = fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName],
-${pushes[1]} = null;
-frame.pc += 3;
+var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+${pushes[0]}=fieldInfo${suffix}.fieldOwnerConstructor[fieldInfo${suffix}.fullFieldName],
+${pushes[1]}=null;
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -481,14 +481,14 @@ table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
-    obj${suffix} = ${pops[0]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var ${pushes[0]} = obj${suffix}[fieldInfo${suffix}.fullFieldName];
-  frame.pc += 3;
-  ${onSuccess}
-} else {
-  ${onError}
+var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+obj${suffix}=${pops[0]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName];
+frame.pc+=3;
+${onSuccess}
+}else{
+${onError}
 }`;
 }};
 
@@ -497,14 +497,14 @@ table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
-    obj${suffix} = ${pops[0]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var ${pushes[0]} = obj${suffix}[fieldInfo${suffix}.fullFieldName], ${pushes[1]} = null;
-  frame.pc += 3;
-  ${onSuccess}
-} else {
-  ${onError}
+var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+obj${suffix}=${pops[0]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var ${pushes[0]}=obj${suffix}[fieldInfo${suffix}.fullFieldName],${pushes[1]}=null;
+frame.pc+=3;
+${onSuccess}
+}else{
+${onError}
 }`;
 }};
 
@@ -513,14 +513,14 @@ table[OpCode.PUTFIELD_FAST32] = {hasBranch: false, pops: 2, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
-    obj${suffix} = ${pops[1]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  obj${suffix}[fieldInfo${suffix}.fullFieldName] = ${pops[0]};
-  frame.pc += 3;
-  ${onSuccess}
-} else {
-  ${onError}
+var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+obj${suffix}=${pops[1]};
+if(!util.isNull(thread,frame,obj${suffix})){
+obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[0]};
+frame.pc+=3;
+${onSuccess}
+}else{
+${onError}
 }`;
 }};
 
@@ -529,14 +529,14 @@ table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (po
   const onError = makeOnError(onErrorPushes);
   const index = code.readUInt16BE(pc + 1);
   return `
-var fieldInfo${suffix} = frame.method.cls.constantPool.get(${index}),
-    obj${suffix} = ${pops[2]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  obj${suffix}[fieldInfo${suffix}.fullFieldName] = ${pops[1]};
-  frame.pc += 3;
-  ${onSuccess}
-} else {
-  ${onError}
+var fieldInfo${suffix}=frame.method.cls.constantPool.get(${index}),
+obj${suffix}=${pops[2]};
+if(!util.isNull(thread,frame,obj${suffix})){
+obj${suffix}[fieldInfo${suffix}.fullFieldName]=${pops[1]};
+frame.pc+=3;
+${onSuccess}
+}else{
+${onError}
 }`;
 }};
 
@@ -544,31 +544,31 @@ if (!util.isNull(thread, frame, obj${suffix})) {
 table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var cls${suffix} = frame.method.cls.constantPool.get(${index}).cls,
-o${suffix} = ${pops[0]},
-${pushes[0]} = o${suffix} !== null ? (o${suffix}.getClass().isCastable(cls${suffix}) ? 1 : 0) : 0;
-frame.pc += 3;
+var cls${suffix}=frame.method.cls.constantPool.get(${index}).cls,
+o${suffix}=${pops[0]},
+${pushes[0]}=o${suffix}!==null?(o${suffix}.getClass().isCastable(cls${suffix})?1:0):0;
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-var  obj${suffix} = ${pops[0]};
-if (!util.isNull(thread, frame, obj${suffix})) {
-  var ${pushes[0]} = obj${suffix}.array.length;
-  frame.pc++;
-  ${onSuccess}
-} else {
-  ${onError}
+var obj${suffix}=${pops[0]};
+if(!util.isNull(thread,frame,obj${suffix})){
+var ${pushes[0]}=obj${suffix}.array.length;
+frame.pc++;
+${onSuccess}
+}else{
+${onError}
 }`;
 }};
 
 const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-var ${pushes[0]} = frame.locals[${index}];
-frame.pc += 2;
+var ${pushes[0]}=frame.locals[${index}];
+frame.pc+=2;
 ${onSuccess}`;
 }}
 
@@ -579,8 +579,8 @@ table[OpCode.FLOAD] = load32;
 const load64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-var ${pushes[0]} = frame.locals[${index}], ${pushes[1]} = null;
-frame.pc += 2;
+var ${pushes[0]}=frame.locals[${index}],${pushes[1]}=null;
+frame.pc+=2;
 ${onSuccess}`;
 }}
 
@@ -590,8 +590,8 @@ table[OpCode.DLOAD] = load64;
 const store32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt8(pc + 1);
   return `
-frame.locals[${index}] = ${pops[0]};
-frame.pc += 2;
+frame.locals[${index}]=${pops[0]};
+frame.pc+=2;
 ${onSuccess}`;
 }}
 
@@ -602,16 +602,16 @@ table[OpCode.FSTORE] = store32;
 table[OpCode.BIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const value = code.readInt8(pc + 1);
   return `
-var ${pushes[0]} = ${value};
-frame.pc += 2;
+var ${pushes[0]}=${value};
+frame.pc+=2;
 ${onSuccess}`;
 }};
 
 table[OpCode.SIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const value = code.readInt16BE(pc + 1);
   return `
-var ${pushes[0]} = ${value};
-frame.pc += 3;
+var ${pushes[0]}=${value};
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -619,8 +619,8 @@ table[OpCode.IINC] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes,
   const idx = code.readUInt8(pc + 1);
   const val = code.readInt8(pc + 2);
   return `
-frame.locals[${idx}] = (frame.locals[${idx}] + ${val}) | 0;
-frame.pc += 3;
+frame.locals[${idx}]=(frame.locals[${idx}]+${val})|0;
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -630,23 +630,23 @@ table[OpCode.ATHROW] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes
   return `
 ${onError}
 thread.throwException(${pops[0]});
-frame.returnToThreadLoop = true;`;
+frame.returnToThreadLoop=true;`;
 }};
 
 table[OpCode.GOTO] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-frame.pc += ${offset};
+frame.pc+=${offset};
 ${onSuccess}`;
 }};
 
 const cmpeq: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} === ${pops[1]}) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}===${pops[1]}){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -657,10 +657,10 @@ table[OpCode.IF_ACMPEQ] = cmpeq;
 const cmpne: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} !== ${pops[1]}) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}!==${pops[1]}){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -671,10 +671,10 @@ table[OpCode.IF_ACMPNE] = cmpne;
 table[OpCode.IF_ICMPGE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[1]} >= ${pops[0]}) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[1]}>=${pops[0]}){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -682,10 +682,10 @@ ${onSuccess}`;
 table[OpCode.IF_ICMPGT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[1]} > ${pops[0]}) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[1]}>${pops[0]}){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -693,10 +693,10 @@ ${onSuccess}`;
 table[OpCode.IF_ICMPLE] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[1]} <= ${pops[0]}) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[1]}<=${pops[0]}){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -704,10 +704,10 @@ ${onSuccess}`;
 table[OpCode.IF_ICMPLT] = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[1]} < ${pops[0]}) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[1]}<${pops[0]}){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -715,10 +715,10 @@ ${onSuccess}`;
 table[OpCode.IFNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} == null) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}==null){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -726,10 +726,10 @@ ${onSuccess}`;
 table[OpCode.IFNONNULL] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} != null) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}!=null){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -737,10 +737,10 @@ ${onSuccess}`;
 table[OpCode.IFEQ] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} === 0) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}===0){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -748,10 +748,10 @@ ${onSuccess}`;
 table[OpCode.IFNE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} !== 0) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}!==0){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -759,10 +759,10 @@ ${onSuccess}`;
 table[OpCode.IFGT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} > 0) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}>0){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -770,10 +770,10 @@ ${onSuccess}`;
 table[OpCode.IFLT] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} < 0) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}<0){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -781,10 +781,10 @@ ${onSuccess}`;
 table[OpCode.IFGE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} >= 0) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}>=0){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
@@ -792,45 +792,45 @@ ${onSuccess}`;
 table[OpCode.IFLE] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const offset = code.readInt16BE(pc + 1);
   return `
-if(${pops[0]} <= 0) {
-  frame.pc += ${offset};
-} else {
-  frame.pc += 3;
+if(${pops[0]}<=0){
+frame.pc+=${offset};
+}else{
+frame.pc+=3;
 }
 ${onSuccess}`;
 }};
 
 table[OpCode.LCMP] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.compare(${pops[1]});
+var ${pushes[0]}=${pops[3]}.compare(${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FCMPL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} > ${pops[0]} ? 1 : -1);
+var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}>${pops[0]}?1:-1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DCMPL] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} > ${pops[1]} ? 1 : -1);
+var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}>${pops[1]}?1:-1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FCMPG] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} === ${pops[1]} ? 0 : (${pops[1]} < ${pops[0]} ? -1 : 1);
+var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}<${pops[0]}?-1:1);
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DCMPG] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} === ${pops[1]} ? 0 : (${pops[3]} < ${pops[1]} ? -1 : 1);
+var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}<${pops[1]}?-1:1);
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -839,11 +839,11 @@ table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes
   // TODO: check flags at JIT time
   // TODO: on error pushes
   return `
-frame.returnToThreadLoop = true;
-if (frame.method.accessFlags.isSynchronized()) {
-  if (!frame.method.methodLock(thread, frame).exit(thread)) {
-    return;
-  }
+frame.returnToThreadLoop=true;
+if(frame.method.accessFlags.isSynchronized()){
+if(!frame.method.methodLock(thread,frame).exit(thread)){
+ return;
+}
 }
 thread.asyncReturn();
 `;
@@ -853,12 +853,8 @@ const return32: JitInfo = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pus
   // TODO: check flags at JIT time
   // TODO: on error pushes
   return `
-frame.returnToThreadLoop = true;
-if (frame.method.accessFlags.isSynchronized()) {
-  if (!frame.method.methodLock(thread, frame).exit(thread)) {
-    return;
-  }
-}
+frame.returnToThreadLoop=true;
+if(frame.method.accessFlags.isSynchronized()){if(!frame.method.methodLock(thread,frame).exit(thread)){return;}}
 thread.asyncReturn(${pops[0]});
 `;
 }};
@@ -869,13 +865,9 @@ table[OpCode.ARETURN] = return32;
 const return64: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix) => {
   // TODO: check flags at JIT time
   return `
-frame.returnToThreadLoop = true;
-if (frame.method.accessFlags.isSynchronized()) {
-  if (!frame.method.methodLock(thread, frame).exit(thread)) {
-    return;
-  }
-}
-thread.asyncReturn(${pops[1]}, null);
+frame.returnToThreadLoop=true;
+if(frame.method.accessFlags.isSynchronized()){if(!frame.method.methodLock(thread,frame).exit(thread)){return;}}
+thread.asyncReturn(${pops[1]},null);
 `;
 }};
 table[OpCode.LRETURN] = return64;
@@ -884,96 +876,96 @@ table[OpCode.DRETURN] = return64;
 table[OpCode.MONITOREXIT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-if (${pops[0]}.getMonitor().exit(thread)) {
+if(${pops[0]}.getMonitor().exit(thread)){
 frame.pc++;
 ${onSuccess}
-} else {
+}else{
 ${onError}
-frame.returnToThreadLoop = true;
+frame.returnToThreadLoop=true;
 }
 `;
 }};
 
 table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} ^ ${pops[1]};
+var ${pushes[0]}=${pops[0]}^${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} | ${pops[1]};
+var ${pushes[0]}=${pops[0]}|${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.or(${pops[1]}), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}.or(${pops[1]}),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IAND] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} & ${pops[1]};
+var ${pushes[0]}=${pops[0]}&${pops[1]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LAND] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.and(${pops[1]}), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}.and(${pops[1]}),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IADD] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[0]} + ${pops[1]}) | 0;
+var ${pushes[0]}=(${pops[0]}+${pops[1]})|0;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.add(${pops[3]}), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[1]}.add(${pops[3]}),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]} + ${pops[3]}, ${pushes[1]} = null;
+var ${pushes[0]}=${pops[1]}+${pops[3]},${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = Math.imul(${pops[0]},  ${pops[1]});
+var ${pushes[0]}=Math.imul(${pops[0]}, ${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.FMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.wrapFloat(${pops[0]} * ${pops[1]});
+var ${pushes[0]}=util.wrapFloat(${pops[0]}*${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}.multiply(${pops[1]}), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}.multiply(${pops[1]}),${pushes[1]}= null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} * ${pops[1]}, ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}*${pops[1]},${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -981,40 +973,40 @@ ${onSuccess}`;
 table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-if (${pops[0]} === 0) {
-  ${onError}
-  util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
-} else {
-  var ${pushes[0]} = (${pops[1]} === util.Constants.INT_MIN && ${pops[0]} === -1) ? ${pops[1]} : ((${pops[1]} / ${pops[0]}) | 0);
-  frame.pc++;
-  ${onSuccess}
+if(${pops[0]}===0){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{
+var ${pushes[0]}=(${pops[1]}===util.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);
+frame.pc++;
+${onSuccess}
 }`;
 }};
 
 table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} / ${pops[1]}, ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}/${pops[1]},${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ISUB] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[1]} - ${pops[0]}) | 0;
+var ${pushes[0]}=(${pops[1]}-${pops[0]})|0;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.negate().add(${pops[3]}), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[1]}.negate().add(${pops[3]}),${pushes[1]}= null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]}-${pops[1]}, ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}-${pops[1]},${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1022,117 +1014,117 @@ ${onSuccess}`;
 table[OpCode.IREM] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-if (${pops[0]} === 0) {
-  ${onError}
-  util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
-} else {
-  var ${pushes[0]} = ${pops[1]} % ${pops[0]};
-  frame.pc++;
-  ${onSuccess}
+if(${pops[0]}===0){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{
+var ${pushes[0]}=${pops[1]}%${pops[0]};
+frame.pc++;
+${onSuccess}
 }`;
 }};
 
 table[OpCode.LREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
   const onError = makeOnError(onErrorPushes);
   return `
-if (${pops[1]}.isZero()) {
-  ${onError}
-  util.throwException(thread, frame, 'Ljava/lang/ArithmeticException;', '/ by zero');
-} else {
-  var ${pushes[0]} = ${pops[3]}.modulo(${pops[1]}), ${pushes[1]} = null;
-  frame.pc++;
-  ${onSuccess}
+if(${pops[1]}.isZero()){
+${onError}
+util.throwException(thread,frame,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{
+var ${pushes[0]}=${pops[3]}.modulo(${pops[1]}),${pushes[1]}=null;
+frame.pc++;
+${onSuccess}
 }`;
 }};
 
 table[OpCode.DREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[3]} % ${pops[1]}, ${pushes[1]} = null;
+var ${pushes[0]}=${pops[3]}%${pops[1]},${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.INEG] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (-${pops[0]}) | 0;
+var ${pushes[0]}=(-${pops[0]})|0;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.negate(), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[1]}.negate(),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ISHL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]} << ${pops[0]};
+var ${pushes[0]}=${pops[1]}<<${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LSHL] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[2]}.shiftLeft(util.gLong.fromInt(${pops[0]})), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[2]}.shiftLeft(util.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.ISHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]} >> ${pops[0]};
+var ${pushes[0]}=${pops[1]}>>${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[2]}.shiftRight(util.gLong.fromInt(${pops[0]})), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[2]}.shiftRight(util.gLong.fromInt(${pops[0]})),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.IUSHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[1]} >>> ${pops[0]}) | 0;
+var ${pushes[0]}=(${pops[1]}>>>${pops[0]})|0;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.LUSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[2]}.shiftRightUnsigned(util.gLong.fromInt(${pops[0]}));
-var ${pushes[1]} = null;
+var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(util.gLong.fromInt(${pops[0]}));
+var ${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2B] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[0]} << 24) >> 24;
+var ${pushes[0]}=(${pops[0]}<<24)>>24;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2S] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = (${pops[0]} << 16) >> 16;
+var ${pushes[0]}=(${pops[0]}<<16)>>16;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2C] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]} & 0xFFFF;
+var ${pushes[0]}=${pops[0]}&0xFFFF;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.I2L] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.gLong.fromInt(${pops[0]}), ${pushes[1]} = null;
+var ${pushes[0]}=util.gLong.fromInt(${pops[0]}),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1145,42 +1137,42 @@ ${onSuccess}`;
 
 table[OpCode.I2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = null;
+var ${pushes[0]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.F2I] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.float2int(${pops[0]});
+var ${pushes[0]}=util.float2int(${pops[0]});
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.F2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = null;
+var ${pushes[0]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.L2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.toInt();
+var ${pushes[0]}=${pops[1]}.toInt();
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.L2D] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}.toNumber(), ${pushes[1]} = null;
+var ${pushes[0]}=${pops[1]}.toNumber(),${pushes[1]}=null;
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.D2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = util.float2int(${pops[1]});
+var ${pushes[0]}=util.float2int(${pops[1]});
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1188,28 +1180,28 @@ ${onSuccess}`;
 // TODO: update the DUPs when peeking is supported
 table[OpCode.DUP] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]}, ${pushes[1]} = ${pops[0]};
+var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP2] = {hasBranch: false, pops: 2, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[1]}, ${pushes[1]} = ${pops[0]}, ${pushes[2]} = ${pops[1]}, ${pushes[3]} = ${pops[0]};
+var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]}, ${pushes[1]} = ${pops[1]}, ${pushes[2]} = ${pops[0]};
+var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[1]},${pushes[2]}=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
 
 table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `
-var ${pushes[0]} = ${pops[0]}, ${pushes[1]} = ${pops[2]}, ${pushes[2]} = ${pops[1]}, ${pushes[3]} = ${pops[0]};
+var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[2]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};
 frame.pc++;
 ${onSuccess}`;
 }};
@@ -1217,9 +1209,9 @@ ${onSuccess}`;
 table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
   const index = code.readUInt16BE(pc + 1);
   return `
-var classRef${suffix} = frame.method.cls.constantPool.get(${index}),
-${pushes[0]} = (new classRef${suffix}.clsConstructor(thread));
-frame.pc += 3;
+var classRef${suffix}=frame.method.cls.constantPool.get(${index}),
+${pushes[0]}=(new classRef${suffix}.clsConstructor(thread));
+frame.pc+=3;
 ${onSuccess}`;
 }};
 
@@ -1228,14 +1220,14 @@ table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pus
   const arrayType = "[" + opcodes.ArrayTypes[index];
   const onError = makeOnError(onErrorPushes);
   return `
-var cls${suffix} = frame.getLoader().getInitializedClass(thread, '${arrayType}');
-if (${pops[0]} >= 0) {
-  var ${pushes[0]} = new (cls${suffix}.getConstructor(thread))(thread, ${pops[0]});
-  frame.pc += 2;
-  ${onSuccess}
-} else {
-  ${onError}
-  util.throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ${arrayType} array with length ' + ${pops[0]});
+var cls${suffix}=frame.getLoader().getInitializedClass(thread,'${arrayType}');
+if(${pops[0]}>=0){
+var ${pushes[0]}=new (cls${suffix}.getConstructor(thread))(thread,${pops[0]});
+frame.pc+=2;
+${onSuccess}
+}else{
+${onError}
+util.throwException(thread,frame,'Ljava/lang/NegativeArraySizeException;','Tried to init ${arrayType} array with length '+${pops[0]});
 }`;
 }};
 
@@ -1244,14 +1236,14 @@ table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pop
   const arrayType = "[" + opcodes.ArrayTypes[index];
   const onError = makeOnError(onErrorPushes);
   return `
-var classRef${suffix} = frame.method.cls.constantPool.get(${index});
-if (${pops[0]} >= 0) {
-  var ${pushes[0]} = new classRef${suffix}.arrayClassConstructor(thread, ${pops[0]});
-  frame.pc += 3;
-  ${onSuccess}
-} else {
-  ${onError}
-  util.throwException(thread, frame, 'Ljava/lang/NegativeArraySizeException;', 'Tried to init ' + classRef${suffix}.arrayClass.getInternalName() + ' array with length ' + ${pops[0]});
+var classRef${suffix}=frame.method.cls.constantPool.get(${index});
+if(${pops[0]}>=0){
+var ${pushes[0]}=new classRef${suffix}.arrayClassConstructor(thread,${pops[0]});
+frame.pc+=3;
+${onSuccess}
+}else{
+${onError}
+util.throwException(thread,frame,'Ljava/lang/NegativeArraySizeException;','Tried to init '+classRef${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});
 }`;
 }};
 

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -370,14 +370,14 @@ table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (po
   return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,${pushes[0]}=${pops[0]}!==null?(${pops[0]}.getClass().isCastable(cls${suffix})?1:0):0;f.pc+=3;${onSuccess}`;
 }};
 
-table[OpCode.CHECKCAST_FAST] = {hasBranch: false, pops: -1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+table[OpCode.CHECKCAST_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
   const index = code.readUInt16BE(pc + 1);
   const classRef = <ConstantPool.ClassReference> method.cls.constantPool.get(index),
     targetClass = classRef.cls.getExternalName();
-  return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,o${suffix}=${pops.length===1?pops[0]:'f.opStack.pop()'};
-if((o${suffix}!=null)&&!o${suffix}.getClass().isCastable(cls${suffix})){
-u.throwException(t,f,'Ljava/lang/ClassCastException;',o${suffix}.getClass().getExternalName()+' cannot be cast to ${targetClass}');
-}else{f.pc+=3;var ${pushes[0]}=o${suffix};${onSuccess}}`
+  return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls;
+if((${pops[0]}!=null)&&!${pops[0]}.getClass().isCastable(cls${suffix})){
+u.throwException(t,f,'Ljava/lang/ClassCastException;',${pops[0]}.getClass().getExternalName()+' cannot be cast to ${targetClass}');
+}else{f.pc+=3;var ${pushes[0]}=${pops[0]};${onSuccess}}`
 }};
 
 table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -579,6 +579,10 @@ table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes,
   return `var ${pushes[0]}=${pops[0]}^${pops[1]};f.pc++;${onSuccess}`;
 }};
 
+table[OpCode.LXOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.xor(${pops[3]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
 table[OpCode.IOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
   return `var ${pushes[0]}=${pops[0]}|${pops[1]};f.pc++;${onSuccess}`;
 }};
@@ -628,6 +632,13 @@ table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes,
   return `
 if(${pops[0]}===0){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
 }else{var ${pushes[0]}=(${pops[1]}===u.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);f.pc++;${onSuccess}}`;
+}};
+
+table[OpCode.LDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(${pops[1]}.isZero()){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=${pops[3]}.div(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}}`;
 }};
 
 table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
@@ -753,6 +764,10 @@ table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushe
 
 table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
   return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[2]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DUP2_X1] = {hasBranch: false, pops: 3, pushes: 5, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[2]},${pushes[3]}=${pops[1]},${pushes[4]}=${pops[0]};f.pc++;${onSuccess}`;
 }};
 
 table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -427,7 +427,11 @@ class JVM {
         assert(false, `Invariant failure: Thread pool cannot be emptied post-JVM termination.`);
         return false;
       case JVMStatus.TERMINATING:
-        methods.dumpStats();
+
+        if (!RELEASE) {
+          methods.dumpStats();
+        }
+
         this.status = JVMStatus.TERMINATED;
         if (this.terminationCb) {
           this.terminationCb(this.exitCode);

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -427,6 +427,7 @@ class JVM {
         assert(false, `Invariant failure: Thread pool cannot be emptied post-JVM termination.`);
         return false;
       case JVMStatus.TERMINATING:
+        methods.dumpStats();
         this.status = JVMStatus.TERMINATED;
         if (this.terminationCb) {
           this.terminationCb(this.exitCode);

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -486,9 +486,9 @@ export class Method extends AbstractMethodField {
         argMaker += `args${suffix}.push(${pops.slice().reverse().join(',')});`;
       }
       return argMaker + `
-var methodReference${suffix} = f.method.cls.constantPool.get(${index});
-methodReference${suffix}.jsConstructor[methodReference${suffix}.fullSignature](t, args${suffix});
-f.returnToThreadLoop = true;
+var methodReference${suffix}=f.method.cls.constantPool.get(${index});
+methodReference${suffix}.jsConstructor[methodReference${suffix}.fullSignature](t,args${suffix});
+f.returnToThreadLoop=true;
 ${onSuccess}`;
     }};
 
@@ -506,14 +506,12 @@ ${onSuccess}`;
         argMaker += `args${suffix}.push(${pops.slice().reverse().join(',')});`;
       }
       return argMaker + `
-var obj${suffix} = ${(paramSize + 1) == pops.length ? pops[paramSize] : "f.opStack.pop();"}
-if (!u.isNull(t, f, obj${suffix})) {
-obj${suffix}[f.method.cls.constantPool.get(${index}).signature](t, args${suffix});
-f.returnToThreadLoop = true;
+var obj${suffix}=${(paramSize+1)==pops.length?pops[paramSize]:"f.opStack.pop();"}
+if(!u.isNull(t,f,obj${suffix})){
+obj${suffix}[f.method.cls.constantPool.get(${index}).signature](t,args${suffix});
+f.returnToThreadLoop=true;
 ${onSuccess}
-} else {
-${onError}
-}`;
+}else{${onError}}`;
     }};
 
   }
@@ -530,15 +528,12 @@ ${onError}
         argMaker += `args${suffix}.push(${pops.slice().reverse().join(',')});`;
       }
       return argMaker + `
-var obj${suffix} = ${(paramSize + 1) == pops.length ? pops[paramSize] : "f.opStack.pop();"}
-if (!u.isNull(t, f, obj${suffix})) {
-var methodReference${suffix} = f.method.cls.constantPool.get(${index});
-obj${suffix}[methodReference${suffix}.fullSignature](t, args${suffix});
-f.returnToThreadLoop = true;
+var obj${suffix}=${(paramSize+1)==pops.length?pops[paramSize]:"f.opStack.pop();"}
+if(!u.isNull(t,f,obj${suffix})){
+obj${suffix}[f.method.cls.constantPool.get(${index}).fullSignature](t,args${suffix});
+f.returnToThreadLoop=true;
 ${onSuccess}
-} else {
-${onError}
-}`;
+}else{${onError}}`;
     }};
   }
 
@@ -550,15 +545,11 @@ ${onError}
     return {hasBranch: false, pops: -1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
       // TODO: could replace oSuffix with pushes[0]
       return `
-var cls${suffix} = f.method.cls.constantPool.get(${index}).cls,
-    o${suffix} = ${pops.length === 1 ? pops[0] : 'f.opStack.pop()'};
-if ((o${suffix} != null) && !o${suffix}.getClass().isCastable(cls${suffix})) {
-  u.throwException(t, f, 'Ljava/lang/ClassCastException;', o${suffix}.getClass().getExternalName() + ' cannot be cast to ${targetClass}');
-} else {
-  f.pc += 3;
-  var ${pushes[0]} = o${suffix};
-  ${onSuccess}
-}`
+var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,
+o${suffix}=${pops.length===1?pops[0]:'f.opStack.pop()'};
+if((o${suffix}!=null)&&!o${suffix}.getClass().isCastable(cls${suffix})){
+u.throwException(t,f,'Ljava/lang/ClassCastException;',o${suffix}.getClass().getExternalName()+' cannot be cast to ${targetClass}');
+}else{f.pc+=3;var ${pushes[0]}=o${suffix};${onSuccess}}`
      }};
 
   }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -394,7 +394,8 @@ export class Method extends AbstractMethodField {
       }
     } else if (!this.accessFlags.isAbstract()) {
       this.code = this.getAttribute('Code');
-      this.jitThreshold = 1000 * this.code.code.length;
+      const codeLength = this.code.code.length;
+      this.jitThreshold = (codeLength > 4) ? 400 * codeLength : 80000 * codeLength;
     }
   }
 

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -602,7 +602,9 @@ u.throwException(t,f,'Ljava/lang/ClassCastException;',o${suffix}.getClass().getE
         const invokeJitInfo: JitInfo = this.makeCheckCastJitInfo(code, i);
         trace.addOp(i, invokeJitInfo);
       } else {
-        // statCloser[op]++;
+        if (trace !== null) {
+          // statCloser[op]++;
+        }
         this.failedCompile[i] = true;
         closeCurrentTrace();
       }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -298,8 +298,10 @@ class Trace {
 
       }
 
-      while(symbolicStack.length > 0) {
-        emitted += `frame.opStack.push(${symbolicStack.shift()});`;
+      if (symbolicStack.length === 1) {
+        emitted += `frame.opStack.push(${symbolicStack[0]});`;
+      } else if (symbolicStack.length > 1) {
+        emitted += `frame.opStack.pushAll(${symbolicStack.join(',')});`;
       }
 
       for (let i = this.infos.length-1; i >= 0; i--) {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -276,7 +276,7 @@ class Trace {
         const jitInfo = info.jitInfo;
 
         const pops = info.pops;
-        for (let i = 0; i < jitInfo.pops; i++) {
+        for (let j = 0; j < jitInfo.pops; j++) {
           if (symbolicStack.length > 0) {
             pops.push(symbolicStack.pop());
           } else {
@@ -289,7 +289,7 @@ class Trace {
         info.onErrorPushes = symbolicStack.slice();
 
         const pushes = info.pushes;
-        for (let i = 0; i < jitInfo.pushes; i++) {
+        for (let j = 0; j < jitInfo.pushes; j++) {
           const symbol = "s" + symbolCount++;
           symbolicStack.push(symbol);
           pushes.push(symbol);

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -551,7 +551,7 @@ ${onError}
       // TODO: could replace oSuffix with pushes[0]
       return `
 var cls${suffix} = f.method.cls.constantPool.get(${index}).cls,
-    o${suffix} = ${pops.length === 1 ? pops[0] : 'f.opStack.top()'};
+    o${suffix} = ${pops.length === 1 ? pops[0] : 'f.opStack.pop()'};
 if ((o${suffix} != null) && !o${suffix}.getClass().isCastable(cls${suffix})) {
   u.throwException(t, f, 'Ljava/lang/ClassCastException;', o${suffix}.getClass().getExternalName() + ' cannot be cast to ${targetClass}');
 } else {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -582,8 +582,10 @@ if(!u.isNull(t,f,obj${suffix})){obj${suffix}['${methodReference.fullSignature}']
         this.failedCompile[i] = true;
         closeCurrentTrace();
       } else {
-        if (trace !== null) {
-          // statCloser[op]++;
+        if (!RELEASE) {
+          if (trace !== null) {
+            statTraceCloser[op]++;
+          }
         }
         this.failedCompile[i] = true;
         closeCurrentTrace();
@@ -886,10 +888,12 @@ function makeOnError(onErrorPushes: string[]) {
   return onErrorPushes.length > 0 ? `f.opStack.pushAll(${onErrorPushes.join(',')});` : '';
 }
 
-const statCloser: number[] = new Array(256);
+const statTraceCloser: number[] = new Array(256);
 
-for (let i = 0; i < 256; i++) {
-  statCloser[i] = 0;
+if (!RELEASE) {
+  for (let i = 0; i < 256; i++) {
+    statTraceCloser[i] = 0;
+  }
 }
 
 export function dumpStats() {
@@ -897,12 +901,12 @@ export function dumpStats() {
   for (let i = 0; i < 256; i++) {
     range[i] = i;
   }
-  range.sort((x, y) => statCloser[y] - statCloser[x]);
+  range.sort((x, y) => statTraceCloser[y] - statTraceCloser[x]);
   const top = range.slice(0, 24);
   for (let i = 0; i < top.length; i++) {
     const op = top[i];
-    if (statCloser[op] > 0) {
-      console.log(enums.OpCode[op], statCloser[op]);
+    if (statTraceCloser[op] > 0) {
+      console.log(enums.OpCode[op], statTraceCloser[op]);
     }
   }
 }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -286,13 +286,6 @@ class Trace {
           }
         }
 
-        // symbolicStack.forEach((e: string) => {info.onError += `frame.opStack.push(${e});`});
-        /*
-        for (let j = 0; j < symbolicStack.length; j++) {
-          const e = symbolicStack[j];
-          info.onError += `frame.opStack.push(${e});`;
-        }
-        */
         info.onErrorPushes = symbolicStack.slice();
 
         const pushes = info.pushes;

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -508,8 +508,7 @@ ${onSuccess}`;
       return argMaker + `
 var obj${suffix} = ${(paramSize + 1) == pops.length ? pops[paramSize] : "f.opStack.pop();"}
 if (!u.isNull(t, f, obj${suffix})) {
-var methodReference${suffix} = f.method.cls.constantPool.get(${index});
-obj${suffix}[methodReference${suffix}.signature](t, args${suffix});
+obj${suffix}[f.method.cls.constantPool.get(${index}).signature](t, args${suffix});
 f.returnToThreadLoop = true;
 ${onSuccess}
 } else {

--- a/src/opcodes.ts
+++ b/src/opcodes.ts
@@ -1530,9 +1530,9 @@ export class Opcodes {
     var methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)),
       opStack = frame.opStack, paramSize = methodReference.paramWordSize,
       obj: JVMTypes.java_lang_Object = opStack.fromTop(paramSize),
-      args = opStack.sliceFromTop(paramSize);
 
     if (!isNull(thread, frame, obj)) {
+      var args = opStack.sliceFromTop(paramSize);
       opStack.dropFromTop(paramSize + 1);
       assert(typeof (<any> obj)[methodReference.fullSignature] === 'function', `Resolved method ${methodReference.fullSignature} isn't defined?!`, thread);
       (<any> obj)[methodReference.fullSignature](thread, args);
@@ -1544,8 +1544,7 @@ export class Opcodes {
     const pc = frame.pc;
     var methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)),
       opStack = frame.opStack, paramSize = methodReference.paramWordSize,
-      args = opStack.sliceFromTop(paramSize);
-    opStack.dropFromTop(paramSize);
+      args = opStack.sliceAndDropFromTop(paramSize);
     assert(methodReference.jsConstructor != null, "jsConstructor is missing?!");
     assert(typeof(methodReference.jsConstructor[methodReference.fullSignature]) === 'function', "Resolved method isn't defined?!");
     methodReference.jsConstructor[methodReference.fullSignature](thread, args);
@@ -1577,9 +1576,8 @@ export class Opcodes {
       appendix = cso[1],
       fcn = cso[0].vmtarget,
       opStack = frame.opStack, paramSize = callSiteSpecifier.paramWordSize,
-      args = opStack.sliceFromTop(paramSize);
+      args = opStack.sliceAndDropFromTop(paramSize);
 
-    opStack.dropFromTop(paramSize);
     if (appendix !== null) {
       args.push(appendix);
     }

--- a/src/opcodes.ts
+++ b/src/opcodes.ts
@@ -1529,7 +1529,7 @@ export class Opcodes {
     const pc = frame.pc;
     var methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)),
       opStack = frame.opStack, paramSize = methodReference.paramWordSize,
-      obj: JVMTypes.java_lang_Object = opStack.fromTop(paramSize),
+      obj: JVMTypes.java_lang_Object = opStack.fromTop(paramSize);
 
     if (!isNull(thread, frame, obj)) {
       var args = opStack.sliceFromTop(paramSize);

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -76,6 +76,13 @@ export class PreAllocatedStack {
     this.store[this.curr++] = x;
   }
 
+  pushAll() {
+    const n = arguments.length;
+    for (let i = 0; i < n; i++) {
+      this.store[this.curr++] = arguments[i];
+    }
+  }
+
   pushWithNull(x: any) {
     this.store[this.curr] = x;
 

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -179,6 +179,12 @@ export class PreAllocatedStack {
     this.curr -= n;
   }
 
+  sliceAndDropFromTop(n: number): any {
+    const curr = this.curr;
+    this.curr -= n;
+    return this.store.slice(curr - n, curr);
+  }
+
   getRaw(): any[] {
     return this.store.slice(0, this.curr);
   }

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -270,9 +270,11 @@ export class BytecodeStackFrame implements IStackFrame {
 
     // Run until we get the signal to return to the thread loop.
     while (!this.returnToThreadLoop) {
-      // var op = code.readUInt8(this.pc);
       var op = method.getOp(this.pc, code);
       if (typeof op === 'function') {
+        if (!RELEASE && logging.log_level === logging.VTRACE) {
+          vtrace(`  ${this.pc} running JIT compiled function:\n${op.toString()}`);
+        }
         op(this, thread, jitUtil);
       } else {
         if (!RELEASE && logging.log_level === logging.VTRACE) {

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -188,6 +188,16 @@ export class PreAllocatedStack {
   }
 }
 
+const jitUtil = {
+  isNull: opcodes.isNull,
+  resolveCPItem: opcodes.resolveCPItem,
+  throwException: opcodes.throwException,
+  gLong: gLong,
+  float2int: util.float2int,
+  wrapFloat: util.wrapFloat,
+  Constants: enums.Constants
+};
+
 /**
  * Represents a stack frame for a bytecode method.
  */
@@ -247,11 +257,16 @@ export class BytecodeStackFrame implements IStackFrame {
 
     // Run until we get the signal to return to the thread loop.
     while (!this.returnToThreadLoop) {
-      var op = code.readUInt8(this.pc);
-      if (!RELEASE && logging.log_level === logging.VTRACE) {
-        vtrace(`  ${this.pc} ${annotateOpcode(op, this, code, this.pc)}`);
+      // var op = code.readUInt8(this.pc);
+      var op = method.getOp(this.pc, code);
+      if (typeof op === 'function') {
+        op(this, thread, jitUtil);
+      } else {
+        if (!RELEASE && logging.log_level === logging.VTRACE) {
+          vtrace(`  ${this.pc} ${annotateOpcode(op, method, code, this.pc)}`);
+        }
+        opcodeTable[op](thread, this, code);
       }
-      opcodeTable[op](thread, this, code);
       if (!RELEASE && !this.returnToThreadLoop && logging.log_level === logging.VTRACE) {
         vtrace(`    S: [${logging.debug_vars(this.opStack.getRaw())}], L: [${logging.debug_vars(this.locals)}]`);
       }
@@ -1322,19 +1337,19 @@ function printConstantPoolItem(cpi: ConstantPool.IConstantPoolItem): string {
 }
 
 // TODO: Prefix behind DEBUG, cache lowercase opcode names.
-export var OpcodeLayoutPrinters: {[layoutAtom: number]: (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => string} = {};
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.OPCODE_ONLY] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)));
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_UINT8] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(frame.method.cls.constantPool.get(code.readUInt8(pc + 1)));
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_AND_UINT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1))) + " " + code.readUInt8(pc + 3);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_AND_INT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1) + " " + code.readInt8(pc + 2);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt8(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT16_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt16BE(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT32_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt32BE(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.ARRAY_TYPE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + opcodes.ArrayTypes[code.readUInt8(pc + 1)];
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.WIDE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
+export var OpcodeLayoutPrinters: {[layoutAtom: number]: (method: methods.Method, code: NodeBuffer, pc: number) => string} = {};
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.OPCODE_ONLY] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(method.cls.constantPool.get(code.readUInt16BE(pc + 1)));
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_UINT8] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(method.cls.constantPool.get(code.readUInt8(pc + 1)));
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_AND_UINT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(method.cls.constantPool.get(code.readUInt16BE(pc + 1))) + " " + code.readUInt8(pc + 3);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_AND_INT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1) + " " + code.readInt8(pc + 2);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt8(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT16_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt16BE(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT32_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt32BE(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.ARRAY_TYPE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + opcodes.ArrayTypes[code.readUInt8(pc + 1)];
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.WIDE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
 
-function annotateOpcode(op: number, frame: BytecodeStackFrame, code: NodeBuffer, pc: number): string {
-  return OpcodeLayoutPrinters[enums.OpcodeLayouts[op]](frame, code, pc);
+export function annotateOpcode(op: number, method: methods.Method, code: NodeBuffer, pc: number): string {
+  return OpcodeLayoutPrinters[enums.OpcodeLayouts[op]](method, code, pc);
 }


### PR DESCRIPTION
:tada:

So, this is what I have been working on for the last few weeks!

Design wise, this is the first-cut, simple version. I have been testing/benchmarking/tweaking the implementation to see how far the design goes, so the implementation is quite stable.

The main purpose of the PR is to get some feedback from @jvilk, et al. Though, I believe it is stable enough to merge (after review).

## Design Overview

Currently, Doppio *interprets* JVM byte code one at a time. The opcodes are stored in an array and the interpreter walks the elements of the array sequentially. Each op-code is executed by invoking a corresponding function. The function is picked through a table indexed by the opcode.

One strategy for improving performance is to compile a sequence of opcodes into an equivalent JS function.

For example, consider this simple Java function:

```
public static int add(int a, int b, int c) {
  return a + b + c;
}
```

which after compilation produces this byte code:

```
public static int add(int, int, int);
  Code:
     0: iload_0
     1: iload_1
     2: iadd
     3: iload_2
     4: iadd
     5: ireturn
```

Instead of interpreting these opcodes one at a time, one could compile a JS function which does that:
```
function add() {
  iload_0();
  iload_1();
  iadd();
  iload_2();
  iadd();
  ireturn();
}
```

This avoids checking the opcodes of the method everytime. However, we can go further.  We can have stackless variants of the opcode implementations. For example, `stackless_iload_0` would return the loaded value rather than push it onto the stack. Similarly, `stackless_iadd` would accept two parameters and return the result, instead of using the stack. The stackless variant would look like:

```
function add() {
  const s0 = stackless_iload_0();
  const s1 = stackless_iload_1();
  const s2 = stackless_iadd(s0, s1);
  const s3 = stackless_iload_2();
  const s4 = stackless_iadd(s2, s3);
  stackless_ireturn(s4);
}
```

Further, the stackless functions could be inlined at the time of emitting, to give this form:

```
function add(frame, thread) {
  const s0 = frame.locals[0];
  const s1 = frame.locals[1];
  const s2 = s0 + s1;
  const s3 = frame.locals[2];
  const s4 = s2 + s3;
  thread.return(s4);
}
```

This form should improve performance since stack operations have been replaced with local variable assignments and the
Javascript VM can optimise this function fully.

Such a function can be emitted as a string and then compiled using JS `eval` or `new Function()`.

The above example is simplistic. There are some gotchas to consider:

*  If the function contains jumps then such a straightforward translation to JS is not possible.
*  If checks for yielding the thread are added, the continuation functions would create too many closures.

One solution is to create separate functions for each "trace", where a trace is defined as a contiguous block of opcodes that don't branch nor yield. A Java function might comprise of multiple such traces, and hence would have multiple JS functions associated with it.


## Tradeoffs

* Identifying traces, generating their JS functions and compiling those functions will increase the warm up time.
* Creating these JS functions would increase memory consumption.

To mitigate these factors, JITing can be restricted to frequently called functions. Currently a very simple heuristic is used: if the count of opcode executions in a method exceeds a threshold, then that method is targeted for JIT compilation.

## Implementation details

### Symbolic stack
To keep track of symbols needed for stackless execution, a symbol stack is maintained similar to the operand stack. The difference is that the symbol stack tracks symbols at JIT time, while the operand stack tracks actual values at run-time.

When an opcode needs to pop two values from the operand stack, the JIT will instead pop two symbols from the symbol stack. When the symbol stack underflows, new symbols are created and initialised from the operand stack.

Similarly, when an opcode needs to push a value to the operand stack, the JIT emitted code will assign the value to a symbol which is then pushed on the symbol stack. This symbol can then be consumed by later opcodes in the `trace`. At the end of the trace, all symbols remaining on the symbol stack are mapped to pushes on the operand stack.

As an example, consider a trace that contains the following opcodes: `IADD`, `IMUL`. The first opcode needs two symbols from the symbolic stack. Since the symbolic stack is initially empty, we create two symbols, s1 and s2, push them to the symbolic stack, and emit code to initialise them:

```
var s1 = frame.opStack.pop();
var s2 = frame.opStack.pop();
```

These symbols are then available to the the `IADD` instruction, for which the following code can be emitted:

```
var s3 = s1 + s2;
```

Here, `s3` is a new symbol that represents the pushed value from `IADD`. This symbol will now be pushed on the symbol stack. When translating the next opcode `IMUL`, we again need two symbols to be popped from the symbol stack. But the stack contains only one symbol `s3`. Hence, a new symbol `s4` is allocated and pushed onto the stack, and code to initialise is emitted:

```
var s4 = frame.opStack.pop();
```

followed by the code for `IMUL`:

```
var s5 = s4 * s3;
```

Finally, at the end of the trace, all values represented by the symbols stack are pushed to the operand stack. In this case, only `s5` is present on the symbol stack, and thus:

```
frame.opStack.push(s5);
```

is emitted. Putting it all together, we get:

```
var s1 = frame.opStack.pop();
var s2 = frame.opStack.pop();
var s3 = s1 + s2;
var s4 = frame.opStack.pop();
var s5 = s4 * s3;
frame.opStack.push(s5);
```

Even in this small example we can see that one opStack push has been eliminated for the `IADD` instruction. The savings are larger for larger traces.

## Benchmarks

I have used the following benchmarks:

* Compilation of a simple Java program using `javac` in `Chromium` and `Firefox`
* Scimark 2 on `nodejs`
* Bubble sort and back-tracking N-Queens on `nodejs`
* Running a Scala program on nodejs

## Benchmark results

| javac   | Total time for JVM | Total time for JVM (after) |
| -----------   | ------------------ | -------------------------- |
| Chromium 49   | 31994              | 17534                      |
| Firefox 45.0.1| 38283              | 24582                      |


| Scimark2      | Score before      | Score after        |
| -----------   | ----------------  | ------------------ |
| node 5.7.1    | 2.194548131157776 | 23.46              |

| Nashorn       | Time before   | Time after     |
| -----------   | ------------  | -------------- |
| node 5.7.1    | 24.85 s       | 18.645s        |

| Abandon.jar  | Time before   | Time after     |
| ----------------- | ------------  | -------------- |
| node 5.7.1        | 90.53s        | 71.22s         |

| Bubble sort + nQueens | Time before   | Total time for JVM | Time after     | Total time for JVM (after) |
| --------------------- | ------------  | ------------------ | -------------- | -------------------------- |
| node 5.7.1            | 56011 ms      | 57.2 s             | 8248 ms        | 10.47 s                    |
### Future ideas

* Detection and optimisations of loops, if-else conditions, etc.
* Inlining functions calls.
