### PR TITLE
JIT compilation, first cut, squashed

### DIFF
--- a/console/runner.ts
+++ b/console/runner.ts
@@ -46,6 +46,7 @@ javaCLI(process.argv.slice(2), {
   nativeClasspath: [path.resolve(__dirname, '../src/natives')],
   launcherName: process.argv[0] + " " + path.relative(process.cwd(), process.argv[1]),
   intMode: false,
+  dumpJITStats: false,
   tmpDir: os.tmpdir()
 }, doneCb, function(jvm: JVM): void {
   jvmState = jvm;

--- a/console/runner.ts
+++ b/console/runner.ts
@@ -45,6 +45,7 @@ javaCLI(process.argv.slice(2), {
   // Override default here; Node builds have different natives directory right now.
   nativeClasspath: [path.resolve(__dirname, '../src/natives')],
   launcherName: process.argv[0] + " " + path.relative(process.cwd(), process.argv[1]),
+  intMode: false,
   tmpDir: os.tmpdir()
 }, doneCb, function(jvm: JVM): void {
   jvmState = jvm;

--- a/console/test_runner.ts
+++ b/console/test_runner.ts
@@ -18,6 +18,7 @@ var opts: testing.TestOptions = {
   enableSystemAssertions: true,
   enableAssertions: true,
   intMode: false,
+  dumpJITStats: false,
   tmpDir: os.tmpdir()
 }, passChar: string, failChar: string;
 

--- a/console/test_runner.ts
+++ b/console/test_runner.ts
@@ -17,6 +17,7 @@ var opts: testing.TestOptions = {
   nativeClasspath: [path.resolve(__dirname, path.join('..', 'src', 'natives'))],
   enableSystemAssertions: true,
   enableAssertions: true,
+  intMode: false,
   tmpDir: os.tmpdir()
 }, passChar: string, failChar: string;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -38,6 +38,8 @@ export interface JVMOptions {
   tmpDir?: string;
   // Responsiveness of JVM (expressed in milliseconds before a thread yields co-operatively)
   responsiveness?: number | (() => number);
+  // Confine to Interpreted mode
+  intMode: boolean;
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,6 +40,8 @@ export interface JVMOptions {
   responsiveness?: number | (() => number);
   // Confine to Interpreted mode
   intMode: boolean;
+  // Dump JIT Statistics
+  dumpJITStats: boolean;
 }
 
 /**

--- a/src/java_cli.ts
+++ b/src/java_cli.ts
@@ -39,6 +39,9 @@ let parser = new OptionParser({
     disablesystemassertions: { alias: 'dsa', desc: 'disable system assertions '}
   },
   X: {
+    'int': {
+      desc: 'interpreted mode execution only'
+    },
     log: {
       desc: 'log level, [0-10]|vtrace|trace|debug|error',
       type: ParseType.NORMAL_VALUE_SYNTAX
@@ -111,6 +114,8 @@ function java(args: string[], opts: JVMCLIOptions,
 
   // GLOBAL CONFIGURATION
   let logOption = nonStandard.stringOption('log', 'ERROR');
+
+  opts.intMode = nonStandard.flag('int', false);
 
   if (/^[0-9]+$/.test(logOption)) {
     logging.log_level = parseInt(logOption, 10);

--- a/src/java_cli.ts
+++ b/src/java_cli.ts
@@ -82,6 +82,9 @@ let parser = new OptionParser({
       type: ParseType.COLON_VALUE_SYNTAX,
       optDesc: ':<directories and zip/jar files separated by :>',
       desc: 'set search path for bootstrap classes and resources'
+    },
+    'PrintCompilation': {
+      desc: 'Print JIT compilation details'
     }
   }
 });
@@ -207,6 +210,8 @@ function java(args: string[], opts: JVMCLIOptions,
       launchJvm(standard, opts, jvmState, doneCb, jvmStarted);
     }
   });
+
+  jvmState.setPrintJITCompilation(nonStandard.flag('PrintCompilation', false));
 
   let vtraceMethods = nonStandard.stringOption('vtrace-methods', null);
   if (vtraceMethods) {

--- a/src/java_cli.ts
+++ b/src/java_cli.ts
@@ -42,6 +42,9 @@ let parser = new OptionParser({
     'int': {
       desc: 'interpreted mode execution only'
     },
+    'dump-JIT-stats': {
+      desc: 'dump JIT statistics'
+    },
     log: {
       desc: 'log level, [0-10]|vtrace|trace|debug|error',
       type: ParseType.NORMAL_VALUE_SYNTAX
@@ -116,6 +119,7 @@ function java(args: string[], opts: JVMCLIOptions,
   let logOption = nonStandard.stringOption('log', 'ERROR');
 
   opts.intMode = nonStandard.flag('int', false);
+  opts.dumpJITStats = nonStandard.flag('dump-JIT-stats', false);
 
   if (/^[0-9]+$/.test(logOption)) {
     logging.log_level = parseInt(logOption, 10);

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -1,0 +1,32 @@
+"use strict";
+
+import enums = require('./enums');
+import opcodes = require('./opcodes');
+import {Method} from './methods';
+import ConstantPool = require('./ConstantPool');
+
+
+export interface JitInfo {
+  pops: number,                 // If negative, then it is treated a request rather than a demand
+  pushes: number,
+  hasBranch: boolean,
+  emit: (pops: string[], pushes: string[], suffix: string, onSuccess: string, code: Buffer, pc: number, onErrorPushes: string[], method: Method) => string
+}
+
+function makeOnError(onErrorPushes: string[]) {
+  return onErrorPushes.length > 0 ? `f.opStack.pushAll(${onErrorPushes.join(',')});` : '';
+}
+
+const escapeStringRegEx = /\\/g;
+
+export const opJitInfo: JitInfo[] = function() {
+
+// Intentionally indented higher: emitted code is shorter.
+
+const table:JitInfo[] = [];
+const OpCode = enums.OpCode;
+
+
+return table;
+}();
+

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -26,6 +26,804 @@ export const opJitInfo: JitInfo[] = function() {
 const table:JitInfo[] = [];
 const OpCode = enums.OpCode;
 
+table[OpCode.ACONST_NULL] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.ICONST_M1] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=-1;f.pc++;${onSuccess}`;
+}};
+
+const load0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[0];f.pc++;${onSuccess}`;
+}};
+
+const load1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[1];f.pc++;${onSuccess}`;
+}};
+
+const load2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[2];f.pc++;${onSuccess}`;
+}};
+
+const load3_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[3];f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.ALOAD_0] = load0_32;
+table[OpCode.ILOAD_0] = load0_32;
+table[OpCode.FLOAD_0] = load0_32;
+
+table[OpCode.ALOAD_1] = load1_32;
+table[OpCode.ILOAD_1] = load1_32;
+table[OpCode.FLOAD_1] = load1_32;
+
+table[OpCode.ALOAD_2] = load2_32;
+table[OpCode.ILOAD_2] = load2_32;
+table[OpCode.FLOAD_2] = load2_32;
+
+table[OpCode.ALOAD_3] = load3_32;
+table[OpCode.ILOAD_3] = load3_32;
+table[OpCode.FLOAD_3] = load3_32;
+
+const load0_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[0],${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+const load1_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[1],${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+const load2_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[2],${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+const load3_64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=f.locals[3],${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LLOAD_0] = load0_64;
+table[OpCode.DLOAD_0] = load0_64;
+
+table[OpCode.LLOAD_1] = load1_64;
+table[OpCode.DLOAD_1] = load1_64;
+
+table[OpCode.LLOAD_2] = load2_64;
+table[OpCode.DLOAD_2] = load2_64;
+
+table[OpCode.LLOAD_3] = load3_64;
+table[OpCode.DLOAD_3] = load3_64;
+
+const store0_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[0]=${pops[0]};f.pc++;${onSuccess}`;
+}}
+
+const store1_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[1]=${pops[0]};f.pc++;${onSuccess}`;
+}}
+
+const store2_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[2]=${pops[0]};f.pc++;${onSuccess}`;
+}}
+
+const store3_32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[3]=${pops[0]};f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.ASTORE_0] = store0_32;
+table[OpCode.ISTORE_0] = store0_32;
+table[OpCode.FSTORE_0] = store0_32;
+
+table[OpCode.ASTORE_1] = store1_32;
+table[OpCode.ISTORE_1] = store1_32;
+table[OpCode.FSTORE_1] = store1_32;
+
+table[OpCode.ASTORE_2] = store2_32;
+table[OpCode.ISTORE_2] = store2_32;
+table[OpCode.FSTORE_2] = store2_32;
+
+table[OpCode.ASTORE_3] = store3_32;
+table[OpCode.ISTORE_3] = store3_32;
+table[OpCode.FSTORE_3] = store3_32;
+
+const store_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readUInt8(pc + 1);
+  return `f.locals[${offset+1}]=${pops[0]};f.locals[${offset}]=${pops[1]};f.pc+=2;${onSuccess}`;
+}}
+
+const store0_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[1]=${pops[0]};f.locals[0]=${pops[1]};f.pc++;${onSuccess}`;
+}}
+
+const store1_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[2]=${pops[0]};f.locals[1]=${pops[1]};f.pc++;${onSuccess}`;
+}}
+
+const store2_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[3]=${pops[0]};f.locals[2]=${pops[1]};f.pc++;${onSuccess}`;
+}}
+
+const store3_64: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.locals[4]=${pops[0]};f.locals[3]=${pops[1]};f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.LSTORE] = store_64;
+table[OpCode.DSTORE] = store_64;
+
+table[OpCode.LSTORE_0] = store0_64;
+table[OpCode.DSTORE_0] = store0_64;
+
+table[OpCode.LSTORE_1] = store1_64;
+table[OpCode.DSTORE_1] = store1_64;
+
+table[OpCode.LSTORE_2] = store2_64;
+table[OpCode.DSTORE_2] = store2_64;
+
+table[OpCode.LSTORE_3] = store3_64;
+table[OpCode.DSTORE_3] = store3_64;
+
+const const0_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=0;f.pc++;${onSuccess}`;
+}}
+const const1_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=1;f.pc++;${onSuccess}`;
+}}
+const const2_32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=2;f.pc++;${onSuccess}`;
+}}
+
+
+table[OpCode.ICONST_0] = const0_32;
+table[OpCode.ICONST_1] = const1_32;
+table[OpCode.ICONST_2] = const2_32;
+
+table[OpCode.FCONST_0] = const0_32;
+table[OpCode.FCONST_1] = const1_32;
+table[OpCode.FCONST_2] = const2_32;
+
+table[OpCode.ICONST_3] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=3;f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.ICONST_4] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=4;f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.ICONST_5] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=5;f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.LCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=u.gLong.ZERO,${pushes[1]}=null;f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.LCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=u.gLong.ONE,${pushes[1]}=null;f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.DCONST_0] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=0,${pushes[1]}=null;f.pc++;${onSuccess}`;
+}}
+
+table[OpCode.DCONST_1] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=1,${pushes[1]}=null;f.pc++;${onSuccess}`;
+}}
+
+const aload32: JitInfo = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(!u.isNull(t,f,${pops[1]})){
+var len${suffix}=${pops[1]}.array.length;
+if(${pops[0]}<0||${pops[0]}>=len${suffix}){
+${onError}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[0]}+" not in length "+len${suffix}+" array of type "+${pops[1]}.getClass().getInternalName());
+}else{var ${pushes[0]}=${pops[1]}.array[${pops[0]}];f.pc++;${onSuccess}}
+}else{${onError}}`;
+}}
+
+
+table[OpCode.IALOAD] = aload32;
+table[OpCode.FALOAD] = aload32;
+table[OpCode.AALOAD] = aload32;
+table[OpCode.BALOAD] = aload32;
+table[OpCode.CALOAD] = aload32;
+table[OpCode.SALOAD] = aload32;
+
+const aload64: JitInfo = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(!u.isNull(t,f,${pops[1]})){
+var len${suffix}=${pops[1]}.array.length;
+if(${pops[0]}<0||${pops[0]}>=len${suffix}){
+${onError}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[0]}+" not in length "+len${suffix}+" array of type "+${pops[1]}.getClass().getInternalName());
+}else{var ${pushes[0]}=${pops[1]}.array[${pops[0]}],${pushes[1]}=null;f.pc++;${onSuccess}}
+}else{${onError}}`;
+}}
+
+
+table[OpCode.DALOAD] = aload64;
+table[OpCode.LALOAD] = aload64;
+
+const astore32: JitInfo = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(!u.isNull(t,f,${pops[2]})){
+var len${suffix}=${pops[2]}.array.length;
+if(${pops[1]}<0||${pops[1]}>=len${suffix}){
+${onError}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[1]}+" not in length "+len${suffix}+" array of type "+${pops[2]}.getClass().getInternalName());
+}else{${pops[2]}.array[${pops[1]}]=${pops[0]};f.pc++;${onSuccess}}
+}else{${onError}}`;
+}}
+
+
+table[OpCode.IASTORE] = astore32;
+table[OpCode.FASTORE] = astore32;
+table[OpCode.AASTORE] = astore32;
+table[OpCode.BASTORE] = astore32;
+table[OpCode.CASTORE] = astore32;
+table[OpCode.SASTORE] = astore32;
+
+const astore64: JitInfo = {hasBranch: false, pops: 4, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(!u.isNull(t,f,${pops[3]})){
+var len${suffix}=${pops[3]}.array.length;
+if(${pops[2]}<0||${pops[2]}>=len${suffix}){
+${onError}
+u.throwException(t,f,'Ljava/lang/ArrayIndexOutOfBoundsException;',""+${pops[2]}+" not in length "+len${suffix}+" array of type "+${pops[3]}.getClass().getInternalName());
+}else{${pops[3]}.array[${pops[2]}]=${pops[1]};f.pc++;${onSuccess}}
+}else{${onError}}`;
+}}
+
+
+table[OpCode.DASTORE] = astore64;
+table[OpCode.LASTORE] = astore64;
+
+// TODO: get the constant at JIT time ?
+table[OpCode.LDC] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const index = code.readUInt8(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `
+var cnst${suffix}=f.method.cls.constantPool.get(${index});
+if(cnst${suffix}.isResolved()){var ${pushes[0]}=cnst${suffix}.getConstant(t);f.pc+=2;${onSuccess}
+}else{${onError}u.resolveCPItem(t,f,cnst${suffix});}`;
+}};
+
+// TODO: get the constant at JIT time ?
+table[OpCode.LDC_W] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const index = code.readUInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `
+var cnst${suffix}=f.method.cls.constantPool.get(${index});
+if(cnst${suffix}.isResolved()){var ${pushes[0]}=cnst${suffix}.getConstant(t);f.pc+=3;${onSuccess}
+}else{${onError}u.resolveCPItem(t,f,cnst${suffix});}`;
+}};
+
+// TODO: get the constant at JIT time ?
+table[OpCode.LDC2_W] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `var ${pushes[0]}=f.method.cls.constantPool.get(${index}).value,${pushes[1]}=null;f.pc+=3;${onSuccess}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.GETSTATIC_FAST32] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `var fi${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=fi${suffix}.fieldOwnerConstructor[fi${suffix}.fullFieldName];f.pc+=3;${onSuccess}`;
+}};
+
+// TODO: get the field info at JIT time ?
+table[OpCode.GETSTATIC_FAST64] = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `
+var fi${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=fi${suffix}.fieldOwnerConstructor[fi${suffix}.fullFieldName],
+${pushes[1]}=null;f.pc+=3;${onSuccess}`;
+}};
+
+table[OpCode.GETFIELD_FAST32] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  const onError = makeOnError(onErrorPushes);
+  const index = code.readUInt16BE(pc + 1);
+  const fieldInfo = <ConstantPool.FieldReference> method.cls.constantPool.get(index);
+  const name = fieldInfo.fullFieldName.replace(escapeStringRegEx, "\\\\")
+  return `if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}['${name}'];f.pc+=3;${onSuccess}}else{${onError}}`;
+}};
+
+table[OpCode.GETFIELD_FAST64] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  const onError = makeOnError(onErrorPushes);
+  const index = code.readUInt16BE(pc + 1);
+  const fieldInfo = <ConstantPool.FieldReference> method.cls.constantPool.get(index);
+  const name = fieldInfo.fullFieldName.replace(escapeStringRegEx, "\\\\")
+  return `if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}['${name}'],${pushes[1]}=null;f.pc+=3;${onSuccess}}else{${onError}}`;
+}};
+
+table[OpCode.PUTFIELD_FAST32] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  const onError = makeOnError(onErrorPushes);
+  const index = code.readUInt16BE(pc + 1);
+  const fieldInfo = <ConstantPool.FieldReference> method.cls.constantPool.get(index);
+  const name = fieldInfo.fullFieldName.replace(escapeStringRegEx, "\\\\")
+  return `if(!u.isNull(t,f,${pops[1]})){${pops[1]}['${name}']=${pops[0]};f.pc+=3;${onSuccess}}else{${onError}}`;
+}};
+
+table[OpCode.PUTFIELD_FAST64] = {hasBranch: false, pops: 3, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  const onError = makeOnError(onErrorPushes);
+  const index = code.readUInt16BE(pc + 1);
+  const fieldInfo = <ConstantPool.FieldReference> method.cls.constantPool.get(index);
+  const name = fieldInfo.fullFieldName.replace(escapeStringRegEx, "\\\\")
+  return `if(!u.isNull(t,f,${pops[2]})){${pops[2]}['${name}']=${pops[1]};f.pc+=3;${onSuccess}}else{${onError}}`;
+}};
+
+// TODO: get the constant at JIT time ?
+table[OpCode.INSTANCEOF_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls,${pushes[0]}=${pops[0]}!==null?(${pops[0]}.getClass().isCastable(cls${suffix})?1:0):0;f.pc+=3;${onSuccess}`;
+}};
+
+table[OpCode.CHECKCAST_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  const index = code.readUInt16BE(pc + 1);
+  const classRef = <ConstantPool.ClassReference> method.cls.constantPool.get(index),
+    targetClass = classRef.cls.getExternalName();
+  return `var cls${suffix}=f.method.cls.constantPool.get(${index}).cls;
+if((${pops[0]}!=null)&&!${pops[0]}.getClass().isCastable(cls${suffix})){
+u.throwException(t,f,'Ljava/lang/ClassCastException;',${pops[0]}.getClass().getExternalName()+' cannot be cast to ${targetClass}');
+}else{f.pc+=3;var ${pushes[0]}=${pops[0]};${onSuccess}}`
+}};
+
+table[OpCode.ARRAYLENGTH] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `if(!u.isNull(t,f,${pops[0]})){var ${pushes[0]}=${pops[0]}.array.length;f.pc++;${onSuccess}}else{${onError}}`;
+}};
+
+const load32: JitInfo = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  return `var ${pushes[0]}=f.locals[${index}];f.pc+=2;${onSuccess}`;
+}}
+
+table[OpCode.ILOAD] = load32;
+table[OpCode.ALOAD] = load32;
+table[OpCode.FLOAD] = load32;
+
+const load64: JitInfo = {hasBranch: false, pops: 0, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  return `var ${pushes[0]}=f.locals[${index}],${pushes[1]}=null;f.pc+=2;${onSuccess}`;
+}}
+
+table[OpCode.LLOAD] = load64;
+table[OpCode.DLOAD] = load64;
+
+const store32: JitInfo = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt8(pc + 1);
+  return `f.locals[${index}]=${pops[0]};f.pc+=2;${onSuccess}`;
+}}
+
+table[OpCode.ISTORE] = store32;
+table[OpCode.ASTORE] = store32;
+table[OpCode.FSTORE] = store32;
+
+table[OpCode.BIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const value = code.readInt8(pc + 1);
+  return `var ${pushes[0]}=${value};f.pc+=2;${onSuccess}`;
+}};
+
+table[OpCode.SIPUSH] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const value = code.readInt16BE(pc + 1);
+  return `var ${pushes[0]}=${value};f.pc+=3;${onSuccess}`;
+}};
+
+table[OpCode.IINC] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const idx = code.readUInt8(pc + 1);
+  const val = code.readInt8(pc + 2);
+  return `f.locals[${idx}]=(f.locals[${idx}]+${val})|0;f.pc+=3;${onSuccess}`;
+}};
+
+// This is marked as hasBranch: true to stop further opcode inclusion during JITC. The name of "hasBranch" ought to be changed.
+table[OpCode.ATHROW] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `${onError}t.throwException(${pops[0]});f.returnToThreadLoop=true;`;
+}};
+
+table[OpCode.GOTO] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const offset = code.readInt16BE(pc + 1);
+  return `f.pc+=${offset};${onSuccess}`;
+}};
+
+table[OpCode.TABLESWITCH] = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  // Ignore padding bytes. The +1 is to skip the opcode byte.
+  const alignedPC = pc + ((4 - (pc + 1) % 4) % 4) + 1;
+  const defaultOffset = code.readInt32BE(alignedPC),
+    low = code.readInt32BE(alignedPC + 4),
+    high = code.readInt32BE(alignedPC + 8);
+  if ((high - low) < 8) {
+    let emitted = `switch(${pops[0]}){`;
+    for (let i = low; i <= high; i++) {
+      const offset = code.readInt32BE(alignedPC + 12+((i-low)*4));
+      emitted += `case ${i}:f.pc+=${offset};break;`;
+    }
+    emitted += `default:f.pc+=${defaultOffset}}${onSuccess}`
+    return emitted;
+  } else {
+    return `if(${pops[0]}>=${low}&&${pops[0]}<=${high}){f.pc+=f.method.getCodeAttribute().getCode().readInt32BE(${alignedPC + 12}+((${pops[0]}-${low})*4))}else{f.pc+=${defaultOffset}}${onSuccess}`;
+  }
+}};
+
+const cmpeq: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}===${pops[1]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IF_ICMPEQ] = cmpeq;
+table[OpCode.IF_ACMPEQ] = cmpeq;
+
+const cmpne: JitInfo = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}!==${pops[1]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IF_ICMPNE] = cmpne;
+table[OpCode.IF_ACMPNE] = cmpne;
+
+table[OpCode.IF_ICMPGE] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}>=${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IF_ICMPGT] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}>${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IF_ICMPLE] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}<=${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IF_ICMPLT] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}<${pops[0]}){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFNULL] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}==null){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFNONNULL] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}!=null){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFEQ] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}===0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFNE] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}!==0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFGT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}>0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFLT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}<0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFGE] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}>=0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.IFLE] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const offset = code.readInt16BE(pc + 1);
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}<=0){f.pc+=${offset};${onError}}else{f.pc+=3;${onSuccess}}`;
+}};
+
+table[OpCode.LCMP] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}.compare(${pops[1]});f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.FCMPL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}>${pops[0]}?1:-1);f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DCMPL] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}>${pops[1]}?1:-1);f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.FCMPG] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]}===${pops[1]}?0:(${pops[1]}<${pops[0]}?-1:1);f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DCMPG] = {hasBranch: false, pops: 4, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}===${pops[1]}?0:(${pops[3]}<${pops[1]}?-1:1);f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.RETURN] = {hasBranch: true, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  // TODO: on error pushes
+  if (method.accessFlags.isSynchronized()) {
+    return `f.returnToThreadLoop=true;if(!f.method.methodLock(t,f).exit(t)){return}t.asyncReturn();`;
+  } else {
+    return `f.returnToThreadLoop=true;t.asyncReturn();`;
+  }
+}};
+
+const return32: JitInfo = {hasBranch: true, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  // TODO: on error pushes
+  if (method.accessFlags.isSynchronized()) {
+    return `f.returnToThreadLoop=true;if(!f.method.methodLock(t,f).exit(t)){return}t.asyncReturn(${pops[0]});`;
+  } else {
+    return `f.returnToThreadLoop=true;t.asyncReturn(${pops[0]});`;
+  }
+}};
+table[OpCode.IRETURN] = return32;
+table[OpCode.FRETURN] = return32;
+table[OpCode.ARETURN] = return32;
+
+const return64: JitInfo = {hasBranch: true, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes, method) => {
+  // TODO: on error pushes
+  if (method.accessFlags.isSynchronized()) {
+    return `f.returnToThreadLoop=true;if(!f.method.methodLock(t,f).exit(t)){return}t.asyncReturn(${pops[1]},null);`;
+  } else {
+    return `f.returnToThreadLoop=true;t.asyncReturn(${pops[1]},null);`;
+  }
+}};
+table[OpCode.LRETURN] = return64;
+table[OpCode.DRETURN] = return64;
+
+table[OpCode.MONITOREXIT] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}.getMonitor().exit(t)){f.pc++;${onSuccess}}else{${onError}f.returnToThreadLoop=true;}`;
+}};
+
+table[OpCode.IXOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]}^${pops[1]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LXOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.xor(${pops[3]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IOR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]}|${pops[1]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LOR] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}.or(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IAND] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]}&${pops[1]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LAND] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}.and(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IADD] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=(${pops[0]}+${pops[1]})|0;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.add(${pops[3]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DADD] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}+${pops[3]},${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=Math.imul(${pops[0]}, ${pops[1]});f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.FMUL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=u.wrapFloat(${pops[0]}*${pops[1]});f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}.multiply(${pops[1]}),${pushes[1]}= null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DMUL] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}*${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IDIV] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(${pops[0]}===0){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=(${pops[1]}===u.Constants.INT_MIN&&${pops[0]}===-1)?${pops[1]}:((${pops[1]}/${pops[0]})|0);f.pc++;${onSuccess}}`;
+}};
+
+table[OpCode.LDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `
+if(${pops[1]}.isZero()){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=${pops[3]}.div(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}}`;
+}};
+
+table[OpCode.DDIV] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}/${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.ISUB] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=(${pops[1]}-${pops[0]})|0;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.negate().add(${pops[3]}),${pushes[1]}= null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DSUB] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}-${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IREM] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[0]}===0){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=${pops[1]}%${pops[0]};f.pc++;${onSuccess}}`;
+}};
+
+table[OpCode.LREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const onError = makeOnError(onErrorPushes);
+  return `if(${pops[1]}.isZero()){${onError}u.throwException(t,f,'Ljava/lang/ArithmeticException;','/ by zero');
+}else{var ${pushes[0]}=${pops[3]}.modulo(${pops[1]}),${pushes[1]}=null;f.pc++;${onSuccess}}`;
+}};
+
+table[OpCode.DREM] = {hasBranch: false, pops: 4, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[3]}%${pops[1]},${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.INEG] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=(-${pops[0]})|0;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LNEG] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.negate(),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.ISHL] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}<<${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LSHL] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[2]}.shiftLeft(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.ISHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}>>${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[2]}.shiftRight(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.IUSHR] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=(${pops[1]}>>>${pops[0]})|0;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.LUSHR] = {hasBranch: false, pops: 3, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[2]}.shiftRightUnsigned(u.gLong.fromInt(${pops[0]})),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.I2B] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=(${pops[0]}<<24)>>24;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.I2S] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=(${pops[0]}<<16)>>16;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.I2C] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]}&0xFFFF;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.I2L] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=u.gLong.fromInt(${pops[0]}),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.I2F] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.I2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.F2I] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=u.float2int(${pops[0]});f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.F2D] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.L2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.toInt();f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.L2D] = {hasBranch: false, pops: 2, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]}.toNumber(),${pushes[1]}=null;f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.D2I] = {hasBranch: false, pops: 2, pushes: 1, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=u.float2int(${pops[1]});f.pc++;${onSuccess}`;
+}};
+
+// TODO: update the DUPs when peeking is supported
+table[OpCode.DUP] = {hasBranch: false, pops: 1, pushes: 2, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DUP2] = {hasBranch: false, pops: 2, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DUP_X1] = {hasBranch: false, pops: 2, pushes: 3, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[1]},${pushes[2]}=${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DUP_X2] = {hasBranch: false, pops: 3, pushes: 4, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[0]},${pushes[1]}=${pops[2]},${pushes[2]}=${pops[1]},${pushes[3]}=${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.DUP2_X1] = {hasBranch: false, pops: 3, pushes: 5, emit: (pops, pushes, suffix, onSuccess) => {
+  return `var ${pushes[0]}=${pops[1]},${pushes[1]}=${pops[0]},${pushes[2]}=${pops[2]},${pushes[3]}=${pops[1]},${pushes[4]}=${pops[0]};f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.NEW_FAST] = {hasBranch: false, pops: 0, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc) => {
+  const index = code.readUInt16BE(pc + 1);
+  return `var cr${suffix}=f.method.cls.constantPool.get(${index}),${pushes[0]}=(new cr${suffix}.clsConstructor(t));f.pc+=3;${onSuccess}`;
+}};
+
+table[OpCode.NEWARRAY] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const index = code.readUInt8(pc + 1);
+  const arrayType = "[" + opcodes.ArrayTypes[index];
+  const onError = makeOnError(onErrorPushes);
+  return `
+var cls${suffix}=f.getLoader().getInitializedClass(t,'${arrayType}');
+if(${pops[0]}>=0){var ${pushes[0]}=new (cls${suffix}.getConstructor(t))(t,${pops[0]});f.pc+=2;${onSuccess}
+}else{${onError}u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init ${arrayType} array with length '+${pops[0]});}`;
+}};
+
+table[OpCode.ANEWARRAY_FAST] = {hasBranch: false, pops: 1, pushes: 1, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+  const index = code.readUInt16BE(pc + 1);
+  const arrayType = "[" + opcodes.ArrayTypes[index];
+  const onError = makeOnError(onErrorPushes);
+  return `
+var cr${suffix}=f.method.cls.constantPool.get(${index});
+if(${pops[0]}>=0){var ${pushes[0]}=new cr${suffix}.arrayClassConstructor(t,${pops[0]});f.pc+=3;${onSuccess}
+}else{${onError}u.throwException(t,f,'Ljava/lang/NegativeArraySizeException;','Tried to init '+cr${suffix}.arrayClass.getInternalName()+' array with length '+${pops[0]});}`;
+}};
+
+table[OpCode.NOP] = {hasBranch: false, pops: 0, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.POP] = {hasBranch: false, pops: 1, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.pc++;${onSuccess}`;
+}};
+
+table[OpCode.POP2] = {hasBranch: false, pops: 2, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+  return `f.pc++;${onSuccess}`;
+}};
 
 return table;
 }();

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -96,6 +96,9 @@ class JVM {
   // The JVM's planned exit code.
   private exitCode: number = 0;
 
+  // is JIT disabled?
+  private jitDisabled: boolean = false;
+
   /**
    * (Async) Construct a new instance of the Java Virtual Machine.
    */
@@ -104,6 +107,8 @@ class JVM {
       throw new TypeError("opts.doppioHomePath *must* be specified.");
     }
     opts = <interfaces.JVMOptions> util.merge(JVM.getDefaultOptions(opts.doppioHomePath), opts);
+
+    this.jitDisabled = opts.intMode;
 
     var bootstrapClasspath: string[] = opts.bootstrapClasspath.map((p: string): string => path.resolve(p)),
       // JVM bootup tasks, from first to last task.
@@ -282,7 +287,8 @@ class JVM {
       disableAssertions: null,
       properties: {},
       tmpDir: '/tmp',
-      responsiveness: 1000
+      responsiveness: 1000,
+      intMode: false
     };
   }
 
@@ -376,6 +382,13 @@ class JVM {
         this.terminationCb(1);
       }
     });
+  }
+
+  /**
+   * Returns 'true' if confined to interpreter mode
+   */
+  public isJITDisabled(): boolean {
+    return this.jitDisabled;
   }
 
   /**

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -98,6 +98,7 @@ class JVM {
 
   // is JIT disabled?
   private jitDisabled: boolean = false;
+  private dumpJITStats: boolean = false;
 
   /**
    * (Async) Construct a new instance of the Java Virtual Machine.
@@ -109,6 +110,7 @@ class JVM {
     opts = <interfaces.JVMOptions> util.merge(JVM.getDefaultOptions(opts.doppioHomePath), opts);
 
     this.jitDisabled = opts.intMode;
+    this.dumpJITStats = opts.dumpJITStats;
 
     var bootstrapClasspath: string[] = opts.bootstrapClasspath.map((p: string): string => path.resolve(p)),
       // JVM bootup tasks, from first to last task.
@@ -288,7 +290,8 @@ class JVM {
       properties: {},
       tmpDir: '/tmp',
       responsiveness: 1000,
-      intMode: false
+      intMode: false,
+      dumpJITStats: false
     };
   }
 
@@ -441,7 +444,7 @@ class JVM {
         return false;
       case JVMStatus.TERMINATING:
 
-        if (!RELEASE) {
+        if (!RELEASE && this.dumpJITStats) {
           methods.dumpStats();
         }
 

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -427,6 +427,11 @@ class JVM {
         assert(false, `Invariant failure: Thread pool cannot be emptied post-JVM termination.`);
         return false;
       case JVMStatus.TERMINATING:
+
+        if (!RELEASE) {
+          methods.dumpStats();
+        }
+
         this.status = JVMStatus.TERMINATED;
         if (this.terminationCb) {
           this.terminationCb(this.exitCode);

--- a/src/jvm.ts
+++ b/src/jvm.ts
@@ -82,6 +82,7 @@ class JVM {
   private enableSystemAssertions: boolean = false;
   private enabledAssertions: boolean | string[] = false;
   private disabledAssertions: string[] = [];
+  private printJITCompilation: boolean = false;
   private systemClassLoader: ClassLoader.ClassLoader = null;
   private nextRef: number = 0;
   // Set of all of the methods we want vtrace to be enabled on.
@@ -756,6 +757,14 @@ eval(mod);
    */
   public getDisabledAssertions(): string[] {
     return this.disabledAssertions;
+  }
+
+  public setPrintJITCompilation(enabledOrNot: boolean) {
+    this.printJITCompilation = enabledOrNot;
+  }
+
+  public shouldPrintJITCompilation(): boolean {
+    return this.printJITCompilation;
   }
 
   /**

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -865,6 +865,7 @@ export function dumpStats() {
   }
   range.sort((x, y) => statTraceCloser[y] - statTraceCloser[x]);
   const top = range.slice(0, 24);
+  console.log("Opcodes that closed a trace (number of times encountered):");
   for (let i = 0; i < top.length; i++) {
     const op = top[i];
     if (statTraceCloser[op] > 0) {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -14,6 +14,7 @@ import Monitor = require('./Monitor');
 import StringOutputStream = require('./StringOutputStream');
 import JVMTypes = require('../includes/JVMTypes');
 import global = require('./global');
+import {JitInfo, opJitInfo} from './jit';
 
 declare var RELEASE: boolean;
 if (typeof RELEASE === 'undefined') global.RELEASE = false;
@@ -226,6 +227,98 @@ export class Field extends AbstractMethodField {
   }
 }
 
+const opcodeSize: number[] = function() {
+  const table:number[] = [];
+  const layoutType = enums.OpcodeLayoutType;
+
+  table[layoutType.OPCODE_ONLY] = 1;
+  table[layoutType.CONSTANT_POOL_UINT8] = 2;
+  table[layoutType.CONSTANT_POOL] = 3;
+  table[layoutType.CONSTANT_POOL_AND_UINT8_VALUE] = 4;
+  table[layoutType.UINT8_VALUE] = 2;
+  table[layoutType.UINT8_AND_INT8_VALUE] = 3;
+  table[layoutType.INT8_VALUE] = 2;
+  table[layoutType.INT16_VALUE] = 3;
+  table[layoutType.INT32_VALUE] = 5;
+  table[layoutType.ARRAY_TYPE] = 2;
+  table[layoutType.WIDE] = 1;
+
+  return table;
+}();
+
+class TraceInfo {
+  pops: string[] = [];
+  pushes: string[] = [];
+  prefixEmit: string = "";
+  onErrorPushes: string[];
+
+  constructor(public pc: number, public jitInfo: JitInfo) {
+  }
+}
+
+class Trace {
+  private infos: TraceInfo[] = [];
+
+  constructor(public startPC: number, private code: Buffer, private method: Method) {
+  }
+
+  public addOp(pc: number, jitInfo: JitInfo) {
+    this.infos.push(new TraceInfo(pc, jitInfo));
+  }
+
+  public close(): Function {
+    if (this.infos.length > 1) {
+      const symbolicStack: string[] = [];
+      let symbolCount = 0;
+      let emitted = "";
+      for (let i = 0; i < this.infos.length; i++) {
+        const info = this.infos[i];
+        const jitInfo = info.jitInfo;
+
+        const pops = info.pops;
+        const normalizedPops = jitInfo.pops < 0 ? Math.min(-jitInfo.pops, symbolicStack.length) : jitInfo.pops;
+        for (let j = 0; j < normalizedPops; j++) {
+          if (symbolicStack.length > 0) {
+            pops.push(symbolicStack.pop());
+          } else {
+            const symbol = "s" + symbolCount++;
+            info.prefixEmit += `var ${symbol} = f.opStack.pop();`;
+            pops.push(symbol);
+          }
+        }
+
+        info.onErrorPushes = symbolicStack.slice();
+
+        const pushes = info.pushes;
+        for (let j = 0; j < jitInfo.pushes; j++) {
+          const symbol = "s" + symbolCount++;
+          symbolicStack.push(symbol);
+          pushes.push(symbol);
+        }
+
+      }
+
+      if (symbolicStack.length === 1) {
+        emitted += `f.opStack.push(${symbolicStack[0]});`;
+      } else if (symbolicStack.length > 1) {
+        emitted += `f.opStack.pushAll(${symbolicStack.join(',')});`;
+      }
+
+      for (let i = this.infos.length-1; i >= 0; i--) {
+        const info = this.infos[i];
+        const jitInfo = info.jitInfo;
+        emitted = info.prefixEmit + jitInfo.emit(info.pops, info.pushes, ""+i, emitted, this.code, info.pc, info.onErrorPushes, this.method);
+      }
+
+      // console.log(`Emitted trace of ${this.infos.length} ops: ` + emitted);
+      // f = frame, t = thread, u = util
+      return new Function("f", "t", "u", emitted);
+    } else {
+      return null;
+    }
+  }
+}
+
 export class Method extends AbstractMethodField {
   /**
    * The method's parameters, if any, in descriptor form.
@@ -253,6 +346,11 @@ export class Method extends AbstractMethodField {
    * TODO: Differentiate between NativeMethod objects and BytecodeMethod objects.
    */
   private code: any;
+
+  private numOpcodeExecs = 0;
+  private jitThreshold = 0;
+  private compiledFunctions: Function[] = [];
+  private failedCompile: boolean[] = [];
 
   constructor(cls: ClassData.ReferenceClassData<JVMTypes.java_lang_Object>, constantPool: ConstantPool.ConstantPool, slot: number, byteStream: ByteStream) {
     super(cls, constantPool, slot, byteStream);
@@ -299,6 +397,8 @@ export class Method extends AbstractMethodField {
       }
     } else if (!this.accessFlags.isAbstract()) {
       this.code = this.getAttribute('Code');
+      const codeLength = this.code.code.length;
+      this.jitThreshold = (codeLength > 4) ? 400 * codeLength : 80000 * codeLength;
     }
   }
 
@@ -345,6 +445,148 @@ export class Method extends AbstractMethodField {
   public getCodeAttribute(): attributes.Code {
     assert(!this.accessFlags.isNative() && !this.accessFlags.isAbstract());
     return this.code;
+  }
+
+  public getOp(pc: number, codeBuffer: Buffer): any {
+    if (this.numOpcodeExecs === this.jitThreshold) {
+      if (!this.failedCompile[pc]) {
+        const cachedCompiledFunction = this.compiledFunctions[pc];
+        if (!cachedCompiledFunction) {
+          const compiledFunction = this.jitCompileFrom(pc);
+          if (compiledFunction) {
+            return compiledFunction;
+          } else {
+            this.failedCompile[pc] = true;
+          }
+        } else {
+          return cachedCompiledFunction;
+        }
+      }
+    } else {
+      this.numOpcodeExecs++;
+    }
+    return codeBuffer.readUInt8(pc);
+  }
+
+  private makeInvokeStaticJitInfo(code: Buffer, pc: number) : JitInfo {
+    const index = code.readUInt16BE(pc + 1);
+    const methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> this.cls.constantPool.get(index);
+    const paramSize = methodReference.paramWordSize;
+    const method = methodReference.jsConstructor[methodReference.fullSignature];
+
+    return {hasBranch: true, pops: -paramSize, pushes: 0, emit: (pops, pushes, suffix, onSuccess) => {
+      const argInitialiser = paramSize > pops.length ? `f.opStack.sliceAndDropFromTop(${paramSize - pops.length});` : `[${pops.reduce((a,b) => b + ',' + a, '')}];`;
+      let argMaker = `var args${suffix}=` + argInitialiser;
+      if ((paramSize > pops.length) && (pops.length > 0)) {
+        argMaker += `args${suffix}.push(${pops.slice().reverse().join(',')});`;
+      }
+      return argMaker + `
+var methodReference${suffix}=f.method.cls.constantPool.get(${index});
+methodReference${suffix}.jsConstructor[methodReference${suffix}.fullSignature](t,args${suffix});
+f.returnToThreadLoop=true;
+${onSuccess}`;
+    }};
+
+  }
+
+  private makeInvokeVirtualJitInfo(code: Buffer, pc: number) : JitInfo {
+    const index = code.readUInt16BE(pc + 1);
+    const methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> this.cls.constantPool.get(index);
+    const paramSize = methodReference.paramWordSize;
+    return {hasBranch: true, pops: -(paramSize + 1), pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+      const onError = makeOnError(onErrorPushes);
+      const argInitialiser = paramSize > pops.length ? `f.opStack.sliceAndDropFromTop(${paramSize - pops.length});` : `[${pops.slice(0, paramSize).reduce((a,b) => b + ',' + a, '')}];`;
+      let argMaker = `var args${suffix}=` + argInitialiser;
+      if ((paramSize > pops.length) && (pops.length > 0)) {
+        argMaker += `args${suffix}.push(${pops.slice().reverse().join(',')});`;
+      }
+      return argMaker + `var obj${suffix}=${(paramSize+1)===pops.length?pops[paramSize]:"f.opStack.pop();"}
+if(!u.isNull(t,f,obj${suffix})){obj${suffix}['${methodReference.signature}'](t,args${suffix});f.returnToThreadLoop=true;${onSuccess}}else{${onError}}`;
+    }};
+
+  }
+
+  private makeInvokeNonVirtualJitInfo(code: Buffer, pc: number) : JitInfo {
+    const index = code.readUInt16BE(pc + 1);
+    const methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> this.cls.constantPool.get(index);
+    const paramSize = methodReference.paramWordSize;
+    return {hasBranch: true, pops: -(paramSize + 1), pushes: 0, emit: (pops, pushes, suffix, onSuccess, code, pc, onErrorPushes) => {
+      const onError = makeOnError(onErrorPushes);
+      const argInitialiser = paramSize > pops.length ? `f.opStack.sliceAndDropFromTop(${paramSize - pops.length});` : `[${pops.slice(0, paramSize).reduce((a,b) => b + ',' + a, '')}];`;
+      let argMaker = `var args${suffix}=` + argInitialiser;
+      if ((paramSize > pops.length) && (pops.length > 0)) {
+        argMaker += `args${suffix}.push(${pops.slice().reverse().join(',')});`;
+      }
+      return argMaker + `var obj${suffix}=${(paramSize+1)===pops.length?pops[paramSize]:"f.opStack.pop();"}
+if(!u.isNull(t,f,obj${suffix})){obj${suffix}['${methodReference.fullSignature}'](t, args${suffix});f.returnToThreadLoop=true;${onSuccess}}else{${onError}}`;
+    }};
+  }
+
+  private jitCompileFrom(startPC: number) {
+    // console.log(`Planning to JIT: ${this.fullSignature} from ${startPC}`);
+    const code = this.code.code;
+    let trace: Trace = null;
+    const _this = this;
+    let done = false;
+
+    function closeCurrentTrace() {
+      if (trace !== null) {
+        // console.log("Tracing method: " + _this.fullSignature);
+        const compiledFunction = trace.close();
+        if (compiledFunction) {
+          _this.compiledFunctions[trace.startPC] = compiledFunction;
+        }
+        trace = null;
+      }
+      done = true;
+    }
+
+    for (let i = startPC; i < code.length && !done;) {
+      const op = code.readUInt8(i);
+      // TODO: handle wide()
+      // console.log(`${i}: ${threading.annotateOpcode(op, this, code, i)}`);
+      const jitInfo = opJitInfo[op];
+      if (jitInfo) {
+        if (trace === null) {
+          trace = new Trace(i, code, _this);
+        }
+        trace.addOp(i, jitInfo);
+        if (jitInfo.hasBranch) {
+          this.failedCompile[i] = true;
+          closeCurrentTrace();
+        }
+      } else if (op === enums.OpCode.INVOKESTATIC_FAST && trace !== null) {
+        const invokeJitInfo: JitInfo = this.makeInvokeStaticJitInfo(code, i);
+        trace.addOp(i, invokeJitInfo);
+
+        this.failedCompile[i] = true;
+        closeCurrentTrace();
+
+      } else if (((op === enums.OpCode.INVOKEVIRTUAL_FAST) || (op === enums.OpCode.INVOKEINTERFACE_FAST)) && trace !== null) {
+        const invokeJitInfo: JitInfo = this.makeInvokeVirtualJitInfo(code, i);
+        trace.addOp(i, invokeJitInfo);
+
+        this.failedCompile[i] = true;
+        closeCurrentTrace();
+      } else if ((op === enums.OpCode.INVOKENONVIRTUAL_FAST) && trace !== null) {
+        const invokeJitInfo: JitInfo = this.makeInvokeNonVirtualJitInfo(code, i);
+        trace.addOp(i, invokeJitInfo);
+
+        this.failedCompile[i] = true;
+        closeCurrentTrace();
+      } else {
+        if (!RELEASE) {
+          if (trace !== null) {
+            statTraceCloser[op]++;
+          }
+        }
+        this.failedCompile[i] = true;
+        closeCurrentTrace();
+      }
+      i += opcodeSize[enums.OpcodeLayouts[op]];
+    }
+
+    return _this.compiledFunctions[startPC];
   }
 
   public getNativeFunction(): Function {
@@ -593,5 +835,32 @@ _create`);
     thread.setStatus(${enums.ThreadStatus.RUNNABLE});
   };
 })(cls.getSpecificMethod("${util.reescapeJVMName(this.cls.getInternalName())}", "${util.reescapeJVMName(this.signature)}"));\n`);
+  }
+}
+
+function makeOnError(onErrorPushes: string[]) {
+  return onErrorPushes.length > 0 ? `f.opStack.pushAll(${onErrorPushes.join(',')});` : '';
+}
+
+const statTraceCloser: number[] = new Array(256);
+
+if (!RELEASE) {
+  for (let i = 0; i < 256; i++) {
+    statTraceCloser[i] = 0;
+  }
+}
+
+export function dumpStats() {
+  const range = new Array(256);
+  for (let i = 0; i < 256; i++) {
+    range[i] = i;
+  }
+  range.sort((x, y) => statTraceCloser[y] - statTraceCloser[x]);
+  const top = range.slice(0, 24);
+  for (let i = 0; i < top.length; i++) {
+    const op = top[i];
+    if (statTraceCloser[op] > 0) {
+      console.log(enums.OpCode[op], statTraceCloser[op]);
+    }
   }
 }

--- a/src/opcodes.ts
+++ b/src/opcodes.ts
@@ -1529,10 +1529,10 @@ export class Opcodes {
     const pc = frame.pc;
     var methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)),
       opStack = frame.opStack, paramSize = methodReference.paramWordSize,
-      obj: JVMTypes.java_lang_Object = opStack.fromTop(paramSize),
-      args = opStack.sliceFromTop(paramSize);
+      obj: JVMTypes.java_lang_Object = opStack.fromTop(paramSize);
 
     if (!isNull(thread, frame, obj)) {
+      var args = opStack.sliceFromTop(paramSize);
       opStack.dropFromTop(paramSize + 1);
       assert(typeof (<any> obj)[methodReference.fullSignature] === 'function', `Resolved method ${methodReference.fullSignature} isn't defined?!`, thread);
       (<any> obj)[methodReference.fullSignature](thread, args);
@@ -1544,8 +1544,7 @@ export class Opcodes {
     const pc = frame.pc;
     var methodReference = <ConstantPool.MethodReference | ConstantPool.InterfaceMethodReference> frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)),
       opStack = frame.opStack, paramSize = methodReference.paramWordSize,
-      args = opStack.sliceFromTop(paramSize);
-    opStack.dropFromTop(paramSize);
+      args = opStack.sliceAndDropFromTop(paramSize);
     assert(methodReference.jsConstructor != null, "jsConstructor is missing?!");
     assert(typeof(methodReference.jsConstructor[methodReference.fullSignature]) === 'function', "Resolved method isn't defined?!");
     methodReference.jsConstructor[methodReference.fullSignature](thread, args);
@@ -1577,9 +1576,8 @@ export class Opcodes {
       appendix = cso[1],
       fcn = cso[0].vmtarget,
       opStack = frame.opStack, paramSize = callSiteSpecifier.paramWordSize,
-      args = opStack.sliceFromTop(paramSize);
+      args = opStack.sliceAndDropFromTop(paramSize);
 
-    opStack.dropFromTop(paramSize);
     if (appendix !== null) {
       args.push(appendix);
     }

--- a/src/opcodes.ts
+++ b/src/opcodes.ts
@@ -959,7 +959,11 @@ export class Opcodes {
   public static ifeq(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() === 0) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -968,7 +972,11 @@ export class Opcodes {
   public static ifne(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() !== 0) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -977,7 +985,11 @@ export class Opcodes {
   public static iflt(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() < 0) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -986,7 +998,11 @@ export class Opcodes {
   public static ifge(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() >= 0) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -995,7 +1011,11 @@ export class Opcodes {
   public static ifgt(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() > 0) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1004,7 +1024,11 @@ export class Opcodes {
   public static ifle(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() <= 0) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1016,7 +1040,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 === v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1027,7 +1055,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 !== v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1038,7 +1070,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 < v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1049,7 +1085,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 >= v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1060,7 +1100,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 > v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1071,7 +1115,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 <= v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1082,7 +1130,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 === v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1093,7 +1145,11 @@ export class Opcodes {
     var v2 = frame.opStack.pop();
     var v1 = frame.opStack.pop();
     if (v1 !== v2) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1102,13 +1158,21 @@ export class Opcodes {
   /* Jump opcodes */
   public static goto(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
-    frame.pc += code.readInt16BE(pc + 1);
+    const offset = code.readInt16BE(pc + 1);
+    frame.pc += offset;
+    if (offset < 0) {
+      frame.method.incrBBEntries();
+    }
   }
 
   public static jsr(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
-    frame.opStack.push(frame.pc + 3);
-    frame.pc += code.readInt16BE(pc + 1);
+    frame.opStack.push(pc + 3);
+    const offset = code.readInt16BE(pc + 1);
+    frame.pc += offset;
+    if (offset < 0) {
+      frame.method.incrBBEntries();
+    }
   }
 
   public static ret(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
@@ -1144,7 +1208,11 @@ export class Opcodes {
     pc += 8;
     for (i = 0; i < nPairs; i++) {
       if (code.readInt32BE(pc) === v) {
-        frame.pc += code.readInt32BE(pc + 4);
+        const offset = code.readInt32BE(pc + 4);
+        frame.pc += offset;
+        if (offset < 0) {
+          frame.method.incrBBEntries();
+        }
         return;
       }
       pc += 8;
@@ -1884,7 +1952,11 @@ export class Opcodes {
   public static ifnull(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() == null) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1893,7 +1965,11 @@ export class Opcodes {
   public static ifnonnull(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
     if (frame.opStack.pop() != null) {
-      frame.pc += code.readInt16BE(pc + 1);
+      const offset = code.readInt16BE(pc + 1);
+      frame.pc += offset;
+      if (offset < 0) {
+        frame.method.incrBBEntries();
+      }
     } else {
       frame.pc += 3;
     }
@@ -1901,7 +1977,11 @@ export class Opcodes {
 
   public static goto_w(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {
     const pc = frame.pc;
-    frame.pc += code.readInt32BE(pc + 1);
+    const offset = code.readInt32BE(pc + 1);
+    frame.pc += offset;
+    if (offset < 0) {
+      frame.method.incrBBEntries();
+    }
   }
 
   public static jsr_w(thread: threading.JVMThread, frame: threading.BytecodeStackFrame, code: Buffer) {

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -255,7 +255,7 @@ export class BytecodeStackFrame implements IStackFrame {
     while (!this.returnToThreadLoop) {
       var op = code.readUInt8(this.pc);
       if (!RELEASE && logging.log_level === logging.VTRACE) {
-        vtrace(`  ${this.pc} ${annotateOpcode(op, this, code, this.pc)}`);
+        vtrace(`  ${this.pc} ${annotateOpcode(op, method, code, this.pc)}`);
       }
       opcodeTable[op](thread, this, code);
       if (!RELEASE && !this.returnToThreadLoop && logging.log_level === logging.VTRACE) {
@@ -1328,19 +1328,19 @@ function printConstantPoolItem(cpi: ConstantPool.IConstantPoolItem): string {
 }
 
 // TODO: Prefix behind DEBUG, cache lowercase opcode names.
-export var OpcodeLayoutPrinters: {[layoutAtom: number]: (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => string} = {};
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.OPCODE_ONLY] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1)));
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_UINT8] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(frame.method.cls.constantPool.get(code.readUInt8(pc + 1)));
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_AND_UINT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(frame.method.cls.constantPool.get(code.readUInt16BE(pc + 1))) + " " + code.readUInt8(pc + 3);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_AND_INT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1) + " " + code.readInt8(pc + 2);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT8_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt8(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT16_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt16BE(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT32_VALUE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt32BE(pc + 1);
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.ARRAY_TYPE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + opcodes.ArrayTypes[code.readUInt8(pc + 1)];
-OpcodeLayoutPrinters[enums.OpcodeLayoutType.WIDE] = (frame: BytecodeStackFrame, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
+export var OpcodeLayoutPrinters: {[layoutAtom: number]: (method: methods.Method, code: NodeBuffer, pc: number) => string} = {};
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.OPCODE_ONLY] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(method.cls.constantPool.get(code.readUInt16BE(pc + 1)));
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_UINT8] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(method.cls.constantPool.get(code.readUInt8(pc + 1)));
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.CONSTANT_POOL_AND_UINT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + printConstantPoolItem(method.cls.constantPool.get(code.readUInt16BE(pc + 1))) + " " + code.readUInt8(pc + 3);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.UINT8_AND_INT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readUInt8(pc + 1) + " " + code.readInt8(pc + 2);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT8_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt8(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT16_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt16BE(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.INT32_VALUE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + code.readInt32BE(pc + 1);
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.ARRAY_TYPE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase() + " " + opcodes.ArrayTypes[code.readUInt8(pc + 1)];
+OpcodeLayoutPrinters[enums.OpcodeLayoutType.WIDE] = (method: methods.Method, code: NodeBuffer, pc: number) => enums.OpCode[code.readUInt8(pc)].toLowerCase();
 
-function annotateOpcode(op: number, frame: BytecodeStackFrame, code: NodeBuffer, pc: number): string {
-  return OpcodeLayoutPrinters[enums.OpcodeLayouts[op]](frame, code, pc);
+export function annotateOpcode(op: number, method: methods.Method, code: NodeBuffer, pc: number): string {
+  return OpcodeLayoutPrinters[enums.OpcodeLayouts[op]](method, code, pc);
 }

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -229,6 +229,7 @@ export class BytecodeStackFrame implements IStackFrame {
    */
   constructor(method: methods.Method, args: any[]) {
     this.method = method;
+    method.incrBBEntries();
     assert(!method.accessFlags.isNative(), 'Cannot run a native method using a BytecodeStackFrame.');
     // @todo This should be a runtime error, since reflection can cause you to
     // try to do this.

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -179,6 +179,12 @@ export class PreAllocatedStack {
     this.curr -= n;
   }
 
+  sliceAndDropFromTop(n: number): any {
+    const curr = this.curr;
+    this.curr -= n;
+    return this.store.slice(curr - n, curr);
+  }
+
   getRaw(): any[] {
     return this.store.slice(0, this.curr);
   }

--- a/src/threading.ts
+++ b/src/threading.ts
@@ -284,7 +284,7 @@ export class BytecodeStackFrame implements IStackFrame {
     } else {
       // Run until we get the signal to return to the thread loop.
       while (!this.returnToThreadLoop) {
-        var op = method.getOp(this.pc, code);
+        var op = method.getOp(this.pc, code, thread);
         if (typeof op === 'function') {
           if (!RELEASE && logging.log_level === logging.VTRACE) {
             vtrace(`  ${this.pc} running JIT compiled function:\n${op.toString()}`);

--- a/tasks/test/harness_common.ts
+++ b/tasks/test/harness_common.ts
@@ -49,7 +49,8 @@ export function getTests(cb: (tests: DoppioTest[]) => void) {
     doppioHomePath: '/sys',
     testClasses: null,
     enableSystemAssertions: true,
-    enableAssertions: true
+    enableAssertions: true,
+    intMode: false
   }, cb);
 }
 

--- a/tasks/test/harness_common.ts
+++ b/tasks/test/harness_common.ts
@@ -50,7 +50,8 @@ export function getTests(cb: (tests: DoppioTest[]) => void) {
     testClasses: null,
     enableSystemAssertions: true,
     enableAssertions: true,
-    intMode: false
+    intMode: false,
+    dumpJITStats: false
   }, cb);
 }
 


### PR DESCRIPTION
This PR is very similar to #440, but with cleaned up commits.

My original description below:

------

This is what I have been working on for the last few weeks!

Design wise, this is the first-cut, simple version. I have been testing/benchmarking/tweaking the implementation to see how far the design goes, so the implementation is quite stable.

The main purpose of the PR is to get some feedback from @jvilk, et al. Though, I believe it is stable enough to merge (after review).

## Design Overview

Currently, Doppio *interprets* JVM byte code one at a time. The opcodes are stored in an array and the interpreter walks the elements of the array sequentially. Each op-code is executed by invoking a corresponding function. The function is picked through a table indexed by the opcode.

One strategy for improving performance is to compile a sequence of opcodes into an equivalent JS function.

For example, consider this simple Java function:

```
public static int add(int a, int b, int c) {
  return a + b + c;
}
```

which after compilation produces this byte code:

```
public static int add(int, int, int);
  Code:
     0: iload_0
     1: iload_1
     2: iadd
     3: iload_2
     4: iadd
     5: ireturn
```

Instead of interpreting these opcodes one at a time, one could compile a JS function which does that:
```
function add() {
  iload_0();
  iload_1();
  iadd();
  iload_2();
  iadd();
  ireturn();
}
```

This avoids checking the opcodes of the method everytime. However, we can go further.  We can have stackless variants of the opcode implementations. For example, `stackless_iload_0` would return the loaded value rather than push it onto the stack. Similarly, `stackless_iadd` would accept two parameters and return the result, instead of using the stack. The stackless variant would look like:

```
function add() {
  const s0 = stackless_iload_0();
  const s1 = stackless_iload_1();
  const s2 = stackless_iadd(s0, s1);
  const s3 = stackless_iload_2();
  const s4 = stackless_iadd(s2, s3);
  stackless_ireturn(s4);
}
```

Further, the stackless functions could be inlined at the time of emitting, to give this form:

```
function add(frame, thread) {
  const s0 = frame.locals[0];
  const s1 = frame.locals[1];
  const s2 = s0 + s1;
  const s3 = frame.locals[2];
  const s4 = s2 + s3;
  thread.return(s4);
}
```

This form should improve performance since stack operations have been replaced with local variable assignments and the
Javascript VM can optimise this function fully.

Such a function can be emitted as a string and then compiled using JS `eval` or `new Function()`.

The above example is simplistic. There are some gotchas to consider:

*  If the function contains jumps then such a straightforward translation to JS is not possible.
*  If checks for yielding the thread are added, the continuation functions would create too many closures.

One solution is to create separate functions for each "trace", where a trace is defined as a contiguous block of opcodes that don't branch nor yield. A Java function might comprise of multiple such traces, and hence would have multiple JS functions associated with it.


## Tradeoffs

* Identifying traces, generating their JS functions and compiling those functions will increase the warm up time.
* Creating these JS functions would increase memory consumption.

To mitigate these factors, JITing can be restricted to frequently called functions. Currently a very simple heuristic is used: if the count of opcode executions in a method exceeds a threshold, then that method is targeted for JIT compilation.

## Implementation details

### Symbolic stack
To keep track of symbols needed for stackless execution, a symbol stack is maintained similar to the operand stack. The difference is that the symbol stack tracks symbols at JIT time, while the operand stack tracks actual values at run-time.

When an opcode needs to pop two values from the operand stack, the JIT will instead pop two symbols from the symbol stack. When the symbol stack underflows, new symbols are created and initialised from the operand stack.

Similarly, when an opcode needs to push a value to the operand stack, the JIT emitted code will assign the value to a symbol which is then pushed on the symbol stack. This symbol can then be consumed by later opcodes in the `trace`. At the end of the trace, all symbols remaining on the symbol stack are mapped to pushes on the operand stack.

As an example, consider a trace that contains the following opcodes: `IADD`, `IMUL`. The first opcode needs two symbols from the symbolic stack. Since the symbolic stack is initially empty, we create two symbols, s1 and s2, push them to the symbolic stack, and emit code to initialise them:

```
var s1 = frame.opStack.pop();
var s2 = frame.opStack.pop();
```

These symbols are then available to the the `IADD` instruction, for which the following code can be emitted:

```
var s3 = s1 + s2;
```

Here, `s3` is a new symbol that represents the pushed value from `IADD`. This symbol will now be pushed on the symbol stack. When translating the next opcode `IMUL`, we again need two symbols to be popped from the symbol stack. But the stack contains only one symbol `s3`. Hence, a new symbol `s4` is allocated and pushed onto the stack, and code to initialise is emitted:

```
var s4 = frame.opStack.pop();
```

followed by the code for `IMUL`:

```
var s5 = s4 * s3;
```

Finally, at the end of the trace, all values represented by the symbols stack are pushed to the operand stack. In this case, only `s5` is present on the symbol stack, and thus:

```
frame.opStack.push(s5);
```

is emitted. Putting it all together, we get:

```
var s1 = frame.opStack.pop();
var s2 = frame.opStack.pop();
var s3 = s1 + s2;
var s4 = frame.opStack.pop();
var s5 = s4 * s3;
frame.opStack.push(s5);
```

Even in this small example we can see that one opStack push has been eliminated for the `IADD` instruction. The savings are larger for larger traces.

## Benchmarks

I have used the following benchmarks:

* Compilation of a simple Java program using `javac` in `Chromium` and `Firefox`
* Scimark 2 on `nodejs`
* Bubble sort and back-tracking N-Queens on `nodejs`
* Running a Scala program on nodejs

## Benchmark results

| javac   | Total time for JVM | Total time for JVM (after) |
| -----------   | ------------------ | -------------------------- |
| Chromium 49   | 31994              | 17534                      |
| Firefox 45.0.1| 38283              | 24582                      |


| Scimark2      | Score before      | Score after        |
| -----------   | ----------------  | ------------------ |
| node 5.7.1    | 2.194548131157776 | 23.46              |

| Nashorn       | Time before   | Time after     |
| -----------   | ------------  | -------------- |
| node 5.7.1    | 24.85 s       | 18.645s        |

| Abandon.jar  | Time before   | Time after     |
| ----------------- | ------------  | -------------- |
| node 5.7.1        | 90.53s        | 71.22s         |

| Bubble sort + nQueens | Time before   | Total time for JVM | Time after     | Total time for JVM (after) |
| --------------------- | ------------  | ------------------ | -------------- | -------------------------- |
| node 5.7.1            | 56011 ms      | 57.2 s             | 8248 ms        | 10.47 s                    |
### Future ideas

* Detection and optimisations of loops, if-else conditions, etc.
* Inlining functions calls.

----

The source code and binaries used for benchmarking, along with a README, are available [here](https://hrj.github.io/static/benchmark-files.tar.bz2).